### PR TITLE
Improve contrast in demo content

### DIFF
--- a/docs/docs.styles.scss
+++ b/docs/docs.styles.scss
@@ -30,6 +30,8 @@ div.rsg--root-1 {
 main[class^="rsg--content"] {
   display: block; /* IE11 fix */
   padding: $space-s $space-xl;
+  background-color: tint($docs-grey, 90%);
+
   @media (max-width: #{$docs-breakpoint}) {
     padding: $space-s $space-m;
   }
@@ -350,7 +352,7 @@ div[class^="rsg--sidebar"] {
 // Previews of the components
 div[class^="rsg--preview"] {
   padding: $space-l / 1.2;
-  background-color: tint($docs-grey, 90%);
+  background-color: $color-white;
   border: 1px solid tint($docs-grey, 50%);
   box-shadow: inset 0 0 $space-xs rgba($color-rich-black, 0.05);
   margin: $space-s 0 0;


### PR DESCRIPTION
As ownClouds colors contain light gray in its color pallet, I recommend a white background to better distinguish colors.

![Bildschirmfoto 2019-03-12 um 12 18 02](https://user-images.githubusercontent.com/12717530/54196228-23b5ba80-44c1-11e9-9d51-723f87d0e0f0.png)
