### PR TITLE
oc-table-cell, oc-table-group and oc-table-row don't need their own d…

### DIFF
--- a/config/docs.config.js
+++ b/config/docs.config.js
@@ -153,6 +153,9 @@ module.exports = {
    */
   ignore: [
     "**/App.vue",
+    "**/elements/OcTableCell.vue",
+    "**/elements/OcTableGroup.vue",
+    "**/elements/OcTableRow.vue",
     "**/__tests__/**",
     "**/*.test.js",
     "**/*.test.jsx",


### PR DESCRIPTION
…ocumentation section ...

They are still listed as element ....

![Screenshot from 2019-03-18 15-35-54](https://user-images.githubusercontent.com/1005065/54537919-99bf9300-4993-11e9-9033-8c6b31723ebc.png)
