### PR TITLE
Bugfix/oc file name and extension handling

### DIFF
--- a/src/elements/OcFile.vue
+++ b/src/elements/OcFile.vue
@@ -1,8 +1,11 @@
 <template>
   <a class="oc-file">
     <oc-icon :name="icon" variation="primary" class="uk-position-center-left" />
-    <span class="oc-file-name">{{ name }}</span
-    ><span v-if="extension" class="oc-file-extension">{{ extension }}</span>
+    <span class="oc-file-name" v-text="_name" /><span
+      v-if="file.extension"
+      class="oc-file-extension"
+      v-text="file.extension"
+    />
   </a>
 </template>
 <script>
@@ -23,27 +26,39 @@ export default {
       default: "folder",
     },
     /**
-     * The extension of the file/folder to be displayed.
+     * A file object with necessary property `name` and an optional property `extension`
      */
-    extension: {
-      type: String,
-      required: false,
-    },
-    /**
-     * The name of the file/folder to be displayed.
-     */
-    name: {
-      type: String,
+    file: {
+      type: Object,
       required: true,
+    },
+  },
+  computed: {
+    _name() {
+      let name = this.file.name,
+        extension = this.file.extension
+
+      if (!extension) {
+        return name
+      }
+
+      return name.substring(0, name.length - extension.length - 1)
     },
   },
 }
 </script>
 <docs>
-    ```jsx
-    <div>
-        <oc-file name="This is a picture"/>
-        <oc-file icon="image" extension="png" name="picture"/>
-    </div>
-    ```
+```jsx
+<ul class="uk-list">
+  <li>
+    <oc-file icon="image" :file="{ name : 'I love flowers.jpg', extension : 'jpg' }" />
+  </li>
+  <li>
+    <oc-file icon="folder" :file="{ name : 'Large folder' }" />
+  </li>
+  <li>
+    <oc-file icon="image" :file="{ name : 'Just kidding, I hate flowers.png', extension : 'png' }" />
+  </li>
+</ul>
+```
 </docs>

--- a/src/elements/OcFile.vue
+++ b/src/elements/OcFile.vue
@@ -1,7 +1,7 @@
 <template>
   <a class="oc-file">
     <oc-icon :name="icon" variation="primary" class="uk-position-center-left" />
-    <span class="oc-file-name" v-text="_name" /><span
+    <span class="oc-file-name" v-text="file.name" /><span
       v-if="file.extension"
       class="oc-file-extension"
       v-text="file.extension"
@@ -26,39 +26,39 @@ export default {
       default: "folder",
     },
     /**
-     * A file object with necessary property `name` and an optional property `extension`
+     * A file object with necessary property `name` and an optional property `extension`.
+     * Please note that the name shall not hold the extension
      */
     file: {
       type: Object,
       required: true,
     },
   },
-  computed: {
-    _name() {
-      let name = this.file.name,
-        extension = this.file.extension
-
-      if (!extension) {
-        return name
-      }
-
-      return name.substring(0, name.length - extension.length - 1)
-    },
-  },
 }
 </script>
 <docs>
-```jsx
-<ul class="uk-list">
-  <li>
-    <oc-file icon="image" :file="{ name : 'I love flowers.jpg', extension : 'jpg' }" />
-  </li>
-  <li>
-    <oc-file icon="folder" :file="{ name : 'Large folder' }" />
-  </li>
-  <li>
-    <oc-file icon="image" :file="{ name : 'Just kidding, I hate flowers.png', extension : 'png' }" />
-  </li>
-</ul>
-```
+  ```jsx
+  <section>
+    <h3 class="uk-heading-divider">
+      File examples
+    </h3>
+    <ul class="uk-list">
+      <li>
+        <oc-file icon="image" :file="{ name : 'I love flowers', extension : 'jpg' }" />
+      </li>
+      <li>
+        <oc-file icon="folder" :file="{ name : 'Large folder' }" />
+      </li>
+      <li>
+        <oc-file icon="image" :file="{ name : 'Just kidding, I hate flowers.png', extension : 'png' }" />
+      </li>
+      <li>
+        <oc-file icon="text" :file="{ name : 'README', extension : 'md' }" />
+      </li>
+      <li>
+        <oc-file icon="archive" :file="{ name : 'package', extension : 'tar.gz' }" />
+      </li>
+    </ul>
+  </section>
+  ```
 </docs>


### PR DESCRIPTION
![Screenshot_2019-03-21 ownCloud Design System(2)](https://user-images.githubusercontent.com/1005065/54739803-a6253500-4bb9-11e9-8489-edbc1cf7054f.png)

@felixheidecke :warning: I propose to not remove the extension from the name within this component. This feels wrong and is not intuitive. Furthermore the usage of the component requires that one knows the extension. It can be removed from the file name before entering the component.

**ToDo: We miss a lot of file type icons!**