### PR TITLE
add file actions and items

### DIFF
--- a/src/elements/OcFile.vue
+++ b/src/elements/OcFile.vue
@@ -1,7 +1,7 @@
 <template>
   <a class="oc-file">
     <oc-icon :name="icon" variation="primary" class="uk-position-center-left" />
-    <span class="oc-file-name" v-text="file.name" /><span
+    <span class="oc-file-name" v-text="file.name" @click="onClick" /><span
       v-if="file.extension"
       class="oc-file-extension"
       v-text="file.extension"
@@ -32,6 +32,16 @@ export default {
     file: {
       type: Object,
       required: true,
+    },
+  },
+  methods: {
+    onClick() {
+      /**
+       * This event is emitted when the user clicks a file
+       * TODO https://vuejs.org/v2/guide/components-custom-events.html#Binding-Native-Events-to-Components
+       * @type {string}
+       */
+      this.$emit("oc-file:click", this.file)
     },
   },
 }

--- a/src/patterns/OcFileActions.vue
+++ b/src/patterns/OcFileActions.vue
@@ -1,0 +1,179 @@
+<template>
+  <div :id="id" uk-offcanvas="mode: slide" class="uk-offcanvas uk-offcanvas-bottom">
+    <div class="uk-offcanvas-bar">
+      <span v-text="_label"></span>
+      <ul class="uk-nav">
+        <template v-for="(action, i) in actions">
+          <li :key="i">
+            <a class="uk-inline" @click="selectAction(action)">
+              <oc-icon v-if="action.icon" :name="action.icon" />
+              <span class="uk-text-top" v-text="action.label" />
+            </a>
+          </li>
+        </template>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style>
+.uk-offcanvas.uk-offcanvas-bottom {
+  left: auto;
+  height: 100vh;
+}
+
+.uk-offcanvas.uk-offcanvas-bottom > .uk-offcanvas-bar {
+  width: 100vw;
+  transform: translateX(0) translateY(100%);
+  top: auto;
+}
+
+.uk-offcanvas.uk-offcanvas-bottom.uk-open > .uk-offcanvas-bar {
+  transform: translateX(0) translateY(0);
+}
+</style>
+
+<script>
+import UIkit from "uikit"
+import { uniqueId as _uniqueId } from "lodash"
+
+/**
+ * Create file actions. will be populated by the event payload `filename` and `actions`
+ *
+ */
+export default {
+  name: "oc-file-actions",
+  status: "prototype",
+  release: "1.0.0",
+  props: {
+    /**
+     * The label to display.
+     */
+    label: {
+      type: String,
+      required: false,
+      default: "Open %s in",
+    },
+  },
+  data() {
+    return {
+      filename: "",
+      actions: [],
+      isOpen: false,
+    }
+  },
+  mounted() {
+    this.$root.$on("oc-file-actions:open", file => {
+      this.showActions(file)
+    })
+    UIkit.util.on(`#${this.id}`, "hide", () => {
+      this.closeActions()
+    })
+  },
+  methods: {
+    showActions(file) {
+      this.filename = file.filename
+      this.actions = file.actions
+      this.isOpen = true
+    },
+    closeActions() {
+      this.isOpen = false
+      this.actions = []
+      this.filename = ""
+    },
+    selectAction(action) {
+      action.onClick()
+      this.closeActions()
+    },
+  },
+  computed: {
+    _label() {
+      return this.label.replace(/\%s/, this.filename)
+    },
+    id() {
+      return _uniqueId("oc-fileaction-")
+    },
+  },
+  watch: {
+    isOpen: function(valNew) {
+      if (valNew) {
+        UIkit.offcanvas(`#${this.id}`).show()
+      } else {
+        UIkit.offcanvas(`#${this.id}`).hide()
+      }
+    },
+  },
+}
+</script>
+
+<docs>
+```jsx
+  <template>
+    <div>
+      <oc-button @click="fileOpen(file)" text="click to open actions"/>
+      <oc-file-actions />
+    </div>
+  </template>
+  <script>
+    export default {
+      data () {
+        return {
+          file: {
+            filename: "My file.ext",
+            // the actions will be filled by a function
+            actions : [
+              {
+                label:'PDF Viewer',
+                icon:'application-pdf',
+                onClick: function(){
+                  alert("PDF")
+                }
+              },
+              {
+                label:'Text editor',
+                icon:'text',
+                onClick: function(){
+                  alert("TXT")
+                }
+              },
+              {
+                label:'Office documents',
+                icon:'x-office-document',
+                onClick: function(){
+                  alert("ODT")
+                }
+              },
+              {
+                label:'Office presentation',
+                icon:'x-office-presentation',
+                onClick: function(){
+                  alert("ODP")
+                }
+              },
+              {
+                label:'Office spreadsheet',
+                icon:'x-office-spreadsheet',
+                onClick: function(){
+                  alert("ODS")
+                }
+              },
+              {
+                label:'Media player',
+                icon:'video',
+                onClick: function(){
+                  alert("MP4")
+                }
+              }
+            ]
+          }
+        }
+      },
+      methods: {
+        fileOpen(file) {
+          this.$root.$emit('oc-file-actions:open', file)
+        },
+      },
+    }
+  </script>
+```
+</docs>

--- a/src/patterns/OcFileList.vue
+++ b/src/patterns/OcFileList.vue
@@ -6,6 +6,11 @@
 <script>
 /**
  * The file list is main component of the ownCloud files app.
+ *
+ * ## TODO
+ *
+ * - [ ] handle large lists with https://github.com/Akryum/vue-virtual-scroller
+ *
  */
 export default {
   name: "oc-table",

--- a/src/templates/Files.vue
+++ b/src/templates/Files.vue
@@ -25,14 +25,19 @@ export default {
       type: String,
       default: "div",
     },
+    /**
+     * The selected file, Has a `name` and `extension` property.
+     */
+    selectedFile: {
+      type: Object,
+    },
   },
 }
 </script>
 
 <style lang="scss" scoped></style>
 
-<docs>
-  ```jsx
+<docs>```jsx
 <template>
   <div><!-- top container to fill the whole screen/area -->
     <oc-dialog name="OcDialog" title="Not implemented">
@@ -116,12 +121,13 @@ export default {
         </oc-table-row>
       </oc-table-group>
       <oc-table-group>
-        <oc-table-row v-for="(i,o) in new Array(3)" :key="o">
+        <oc-table-row v-for="(file,o) in files" :key="o">
           <oc-table-cell>
             <oc-checkbox />
           </oc-table-cell>
           <oc-table-cell>
-            <oc-file :file="{ name : 'Picture ' + ++o, extension : 'png' }"/>
+            <!-- FIXME dont register a click handler for every file. register it on the table and get the filename from the event --> 
+            <oc-file @oc-file:click="selectFile(file)" :file="file" :icon="file.icon"/>
           </oc-table-cell>
           <oc-table-cell class="uk-text-muted uk-text-nowrap" v-text=" (++o * 128) + ' Kb'" />
           <oc-table-cell class="uk-text-muted uk-text-nowrap uk-visible@s" v-text=" ++o + ' days ago'" />
@@ -135,6 +141,7 @@ export default {
         </oc-table-row>
       </oc-table-group>
     </oc-table>
+    
     <oc-dialog name="createFolder" title="Create Folder" v-model="createFolder">
       <template slot="content">
         <oc-text-input placeholder="New Folder Name"/>
@@ -153,15 +160,102 @@ export default {
         <oc-button @click="createFile = false" class="uk-modal-close" text="Cancel" variation="secondary" type="button"></oc-button>
       </template>
     </oc-dialog>
+
+    <oc-file-actions />
   </div>
 </template>
 <script>
-export default {
-  data: () => ({
-    createFile: false,
-    createFolder: false
-  })
-}
+  export default {
+    data () {
+      return {
+        createFile: false,
+        createFolder: false,
+        files: [
+          {name: "Private", extension: "", icon:'folder'},
+          {name: "Project", extension: "", icon:'folder-shared'},
+          {name: "Document", extension: "pdf", icon:'application-pdf'},
+          {name: "Picture", extension: "png", icon:'image'},
+          {name: "Presentation", extension: "odp", icon:'x-office-presentation'},
+          {name: "README", extension: "md", icon:'text'},
+          {name: "Spreadsheet", extension: "ods", icon:'x-office-spreadsheet'},
+          {name: "Textdocument", extension: "odt", icon:'x-office-document'},
+          {name: "Video", extension: "mp4", icon:'video'},
+          {name: "Welcome", extension: "txt", icon:'text'},
+        ],
+        actions: {
+          "pdf": [{
+            label:'PDF Viewer',
+            icon:'application-pdf',
+            onClick: function(){
+              alert("PDF")
+            }
+          }],
+          "txt": [{
+            label:'Text editor',
+            icon:'text',
+            onClick: function(){
+              alert("TXT")
+            }
+          },{
+            label:'Markdown editor',
+            icon:'text',
+            onClick: function(){
+              alert("MD")
+            }
+          }],
+          "md": [{
+            label:'Markdown editor',
+            icon:'text',
+            onClick: function(){
+              alert("MD")
+            }
+          },{
+            label:'Text editor',
+            icon:'text',
+            onClick: function(){
+              alert("TXT")
+            }
+          }],
+          "odt": [{
+            label:'Office documents',
+            icon:'x-office-document',
+            onClick: function(){
+              alert("ODT")
+            }
+          }],
+          "odp": [{
+            label:'Office presentation',
+            icon:'x-office-presentation',
+            onClick: function(){
+              alert("ODP")
+            }
+          }],
+          "ods": [{
+            label:'Office spreadsheet',
+            icon:'x-office-spreadsheet',
+            onClick: function(){
+              alert("ODS")
+            }
+          }],
+          "mp4": [{
+            label:'Media player',
+            icon:'video',
+            onClick: function(){
+              alert("MP4")
+            }
+          }]
+        }
+      }
+    },
+    methods: {
+      selectFile(file) {
+        this.$root.$emit('oc-file-actions:open', {
+          filename: file.name + "." + file.extension,
+          actions: this.actions[file.extension]
+        })
+      },
+    },
+  }
 </script>
-  ```
+```
 </docs>


### PR DESCRIPTION
This is a first approach:

![Auswahl_013](https://user-images.githubusercontent.com/956847/55000879-be3eef00-4fd3-11e9-8f90-bfb8cf34acd5.png)

Several questions:
1. I combined an `offcanvas`, `nav` and a `span` for this. It does slide in from the left, but we could use `mode: none` to make it just appear. The css for sliding the div in from the bottom eludes me. I already added css to make the canvas appear at the bottom, see [the upstream issue comment](https://github.com/uikit/uikit/issues/3445#issuecomment-437058627). Not the cleanest approach. And it is not modal ... if we even want that.
2. Does using an offcanvas make it easier for mobile navigation?
3. What about the label?
  a. How do we combine the text with the filename? I currently use a simple string replace.
  b. How do wo translate the "Open %s in" string?
4. How do we always close the action items offcanvas when an action item is clicked. Currently, I use ` uk-toggle="target: #file-actions"` in the item to reference the offcanvas, but that hardcodes an id into the element. We could also move that toggle to the template, but I guess there is a proper way to do that (via js, but a naive `UIkit.offcanvas("#file-actions").hide()` says it can't find UIkit and it would hardcode the id as well)?
