### PR TITLE
yarn add jest-resolve jest-haste-map

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,8 @@
     "http-proxy-middleware": "^0.19.1",
     "husky": "^1.3.1",
     "jest": "^24.5.0",
+    "jest-haste-map": "^24.5.0",
+    "jest-resolve": "^24.5.0",
     "jest-serializer-vue": "^2.0.2",
     "node-notifier": "^5.4.0",
     "node-sass": "^4.11.0",


### PR DESCRIPTION
Fix these warning in yarn install:
```
[4/5] Linking dependencies...
warning "jest > jest-cli > @jest/core > jest-resolve-dependencies@24.5.0" has unmet peer dependency "jest-resolve@^24.1.0".
warning "jest > jest-cli > jest-config > jest-resolve@24.5.0" has unmet peer dependency "jest-haste-map@^24.0.0".
[5/5] Building fresh packages...
