### PR TITLE
oc-menu-item for usage in subnav slot inside oc-menu

### DIFF
--- a/src/elements/OcMenuItem.vue
+++ b/src/elements/OcMenuItem.vue
@@ -1,0 +1,71 @@
+<template>
+  <li @click="onClick">
+    <a href="#">
+      <!-- @slot This default slot is set as content & will override icon -->
+      <slot name="default">
+        <oc-icon v-if="icon" :name="icon" />
+        {{ content }}
+      </slot>
+    </a>
+  </li>
+</template>
+<script>
+/**
+ * Create a menu item.
+ */
+export default {
+  name: "oc-menu-item",
+  status: "prototype",
+  release: "0.0.1",
+  props: {
+    /**
+     * The content to display.
+     */
+    content: {
+      type: String,
+      required: false,
+      default: "",
+    },
+    /**
+     * The icon to display.
+     */
+    icon: {
+      type: String,
+      required: false,
+      default: "",
+    },
+  },
+  methods: {
+    onClick(val) {
+      /**
+       * Click event
+       * @event click
+       * @type {event}
+       */
+      this.$emit("click", val)
+    },
+  },
+}
+</script>
+
+<docs>
+```jsx
+<template>
+    <oc-menu buttonText="open oc-menu">
+      <template slot="subnav">
+        <oc-menu-item icon="create_new_folder" content="New folder …" />
+        <oc-menu-item>Another action</oc-menu-item>
+      </template>
+    </oc-menu>
+  </template>
+  <script>
+    export default {
+      methods: {
+        onClick(val) {
+          alert(val)
+        }
+      }
+    }
+  </script>
+```
+</docs>

--- a/src/patterns/OcMenu.vue
+++ b/src/patterns/OcMenu.vue
@@ -4,7 +4,12 @@
       <oc-button variation="primary" type="button" :text="buttonText"></oc-button>
     </slot>
     <div uk-dropdown="mode: click, offset: 0">
-      <slot />
+      <!-- @slot The default slot for inner content  -->
+      <slot name="default"> </slot>
+      <ul class="uk-nav uk-dropdown-nav uk-nav-default">
+        <!-- @slot This slot receives oc-menu-items as content -->
+        <slot name="subnav" />
+      </ul>
     </div>
   </div>
 </template>
@@ -42,12 +47,13 @@ export default {
         <oc-menu buttonText="Click Me!">
             Welcome to ownCloud Design System!
         </oc-menu>
-        <oc-menu buttonText="Click to open ...">
-            <!-- TODO: replace with oc-list elements-->
-            <ul class="uk-nav uk-dropdown-nav uk-nav-default">
-                <li><a href="#"><oc-icon name="create_new_folder"/>New folder ...</a> </li>
-                <li><a href="#"><oc-icon name="save"/>New file ...</a> </li>
-            </ul>
+        <oc-menu buttonText="Put &lt;oc-menu-item&gt; into the 'subnav' slot ...">
+          <template slot="subnav">
+                <oc-menu-item icon="create_new_folder" content="New folder …" />
+                <oc-menu-item icon="save" content="New file …" />
+                <oc-menu-item content="iconless action" />
+                <oc-menu-item>Another action</oc-menu-item>
+          </template>
         </oc-menu>
         <br />
         <oc-menu buttonText="Click Me!">

--- a/src/templates/Files.vue
+++ b/src/templates/Files.vue
@@ -74,11 +74,10 @@ export default {
         <template slot="right">
             <div class="uk-navbar-item">
                 <oc-menu buttonText="+ New">
-                    <!-- TODO: replace with oc-list elements-->
-                    <ul class="uk-nav uk-dropdown-nav uk-nav-default">
-                        <li @click="createFolder = true"><a href="#"><oc-icon name="create_new_folder"/>New folder ...</a> </li>
-                        <li @click="createFile = true"><a href="#"><oc-icon name="save"/>New file ...</a> </li>
-                    </ul>
+                  <template slot="subnav">
+                    <oc-menu-item icon="create_new_folder" content="New folder …" />
+                    <oc-menu-item icon="save" content="New file …" />
+                  </template>
                 </oc-menu>
             </div>
             <div class="uk-navbar-item">
@@ -91,13 +90,20 @@ export default {
                             <oc-icon name="filter_list"></oc-icon>
                         </div>
                     </template>
-                    <!-- TODO: replace with oc-list elements-->
-                    <ul class="uk-nav uk-dropdown-nav uk-nav-default">
-                        <li>Files<oc-checkbox></oc-checkbox></li>
-                        <li>Folders<oc-checkbox></oc-checkbox></li>
-                        <li>Hidden files<oc-checkbox></oc-checkbox></li>
-                        <li>Files by name<oc-text-input></oc-text-input></li>
-                    </ul>
+                    <template slot="subnav">
+                      <oc-menu-item>
+                        Files<oc-checkbox></oc-checkbox>
+                      </oc-menu-item>
+                      <oc-menu-item>
+                        Folders<oc-checkbox></oc-checkbox>
+                      </oc-menu-item>
+                      <oc-menu-item>
+                        Hidden files<oc-checkbox></oc-checkbox>
+                      </oc-menu-item>
+                      <oc-menu-item>
+                        Files by name<oc-input></oc-input>
+                      </oc-menu-item>
+                    </template>
                 </oc-menu>
             </div>
         </template>


### PR DESCRIPTION
close #101 


- introduce `oc-menu-item` element for usage inside `oc-menu`
- introduce subnav slot in  `oc-menu-item` including `ul` 