### PR TITLE
Ligher icon in disabled buttons

### DIFF
--- a/src/elements/OcButton.vue
+++ b/src/elements/OcButton.vue
@@ -152,11 +152,18 @@ export default {
       <oc-button text="Small" size="small" />
 
       <h3 class="uk-heading-divider">
+        Button with icons
+      </h3>
+      <oc-button icon="home" text="Home"/>
+      <oc-button variation="primary" icon="save" text="Save" />
+      <oc-button icon="save" text="Save disabled" disabled />
+
+      <h3 class="uk-heading-divider">
         Using buttons in a group
       </h3>
       <div class="uk-button-group">
-        <oc-button variation="primary" icon="home" />
-        <oc-button variation="secondary" icon="close" />
+        <oc-button variation="primary">Hello</oc-button>
+        <oc-button variation="secondary">What's up?</oc-button>
         <oc-button text="Demo Button" icon="folder" />
       </div>
     </section>

--- a/src/styles/theme/_variables.scss
+++ b/src/styles/theme/_variables.scss
@@ -10,6 +10,7 @@ $global-link-hover-color: $link-hover-color;
 
 $global-muted-background: $muted-background;
 $global-primary-background: $primary-background;
+$global-secondary-background: $secondary-background;
 
 $global-success-background: $success-background;
 $global-warning-background: $warning-background;

--- a/src/styles/theme/oc-button.scss
+++ b/src/styles/theme/oc-button.scss
@@ -8,6 +8,12 @@
   text-transform: uppercase;
 }
 
+@mixin hook-button-disabled() {
+  .oc-icon > svg {
+    fill: lighten($global-muted-color, 25%);
+  }
+}
+
 //
 // Component: OC Button
 //


### PR DESCRIPTION
Propagate token color to theme

<img width="526" alt="Bildschirmfoto 2019-04-08 um 15 02 21" src="https://user-images.githubusercontent.com/12717530/55726118-5e9f0580-5a0f-11e9-819b-3fa31caf452f.png">

Fixes: https://github.com/owncloud/owncloud-design-system/issues/193