### PR TITLE
[IE11] Give topbar a min height

### DIFF
--- a/src/styles/theme/oc-topbar.scss
+++ b/src/styles/theme/oc-topbar.scss
@@ -4,6 +4,7 @@
   @extend .uk-navbar-container;
   @extend .uk-navbar-transparent;
   @extend .uk-background-primary;
+  min-height: $navbar-nav-item-height;
 
   // Force inverse color,
   // without forcing it too hard


### PR DESCRIPTION
Add a min-height to the top-bar so that it doesn't collapse in IE11