### PR TITLE
Align ocDrop Element to its boundary

### DIFF
--- a/src/elements/OCDrop.vue
+++ b/src/elements/OCDrop.vue
@@ -30,6 +30,18 @@ export default {
       default: "- *",
     },
     /**
+     * The position of the drop.
+     **/
+    position: {
+      type: String,
+      default: "bottom-left",
+      validator: value => {
+        return value.match(
+          /((top|bottom)-(left|center|right|justify)|(left|right)-(top|center|bottom))/
+        )
+      },
+    },
+    /**
      * Comma separated list of drop trigger behaviour modes: `click or hover`
      **/
     mode: {
@@ -45,7 +57,9 @@ export default {
     options: {
       type: Object,
       default() {
-        return {}
+        return {
+          "boundary-align": true,
+        }
       },
     },
   },
@@ -55,9 +69,10 @@ export default {
       let boundary = this.boundary || this.toggle
       let toggle = this.toggle
       let mode = this.mode
+      let pos = this.position
 
       // Collected properties
-      let props = Object.assign({ boundary, toggle, mode }, this.options)
+      let props = Object.assign({ boundary, toggle, mode, pos }, this.options)
 
       return JSON.stringify(props)
     },


### PR DESCRIPTION
Fixes element not properly aligning with the boundary.

* Allow propper boundary-allignment

---

_Alignment example with search dropdown in small viewports_
![FireShot Capture 019 - ownCloud Phoenix - 192 168 2 82](https://user-images.githubusercontent.com/12717530/59757931-17de4f00-928d-11e9-9655-973283a10bff.png)
