### PR TITLE
Removed right margin from sidebar close button

### DIFF
--- a/src/patterns/OcAppSideBar.vue
+++ b/src/patterns/OcAppSideBar.vue
@@ -6,7 +6,7 @@
           <slot name="action">
             <oc-button
               icon="close"
-              class="uk-float-right uk-margin-small-right"
+              class="uk-float-right"
               @click="$emit('close', $event)"
             ></oc-button>
           </slot>


### PR DESCRIPTION
## Motivation
If the button would need the margin/padding it can be added either in theme or if user adds custom close element with it. This way we don't need to remove it in case we are using padding for the whole sidebar.