### PR TITLE
[Upstream] Add stopClassPropagation to help pattern styling

### DIFF
--- a/src/elements/OcButton.vue
+++ b/src/elements/OcButton.vue
@@ -106,6 +106,13 @@ export default {
         return value.match(/(default|primary|secondary)/)
       },
     },
+    /**
+     * Don't add the element class to this element.
+     */
+    stopClassPropagation: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     $_ocButton_iconClass() {
@@ -114,6 +121,8 @@ export default {
         : "uk-position-center"
     },
     $_ocButton_buttonClass() {
+      if (this.stopClassPropagation) return ""
+
       let classes = ["oc-button"]
 
       if (this.variation && !this.disabled) classes.push(`uk-button-${this.variation}`)

--- a/src/elements/OcTextInput.vue
+++ b/src/elements/OcTextInput.vue
@@ -1,6 +1,6 @@
 <template>
   <input
-    class="oc-text-input"
+    :class="{ 'oc-text-input': !stopClassPropagation }"
     :type="type"
     :value="value"
     :placeholder="placeholder"
@@ -47,6 +47,13 @@ export default {
     placeholder: {
       type: String,
       default: null,
+    },
+    /**
+     * Don't add the element class to this element.
+     */
+    stopClassPropagation: {
+      type: Boolean,
+      default: false,
     },
   },
   methods: {


### PR DESCRIPTION
The `stopClassPropagation` removes all styles from the component in order to maintain functionality and apply styles from the pattern without tedious overrides.

Upstream Changes from Customer theme