### PR TITLE
force body inherit overflow and height values in docs.styles

### DIFF
--- a/docs/docs.styles.scss
+++ b/docs/docs.styles.scss
@@ -21,6 +21,11 @@ $docs-color-text: shade($color-silver, 70%);
 /* BASE
 --------------------------------------------- */
 
+body {
+  overflow: inherit !important;
+  height: inherit !important;
+}
+
 // Background of page
 div.rsg--root-1 {
   background: $color-white;


### PR DESCRIPTION
Fixes the issue, where Phoenix body layout values negatively affect the documentation.
Namely not being able to scroll ODS Docs anymore.