### PR TITLE
Autocomplete dropdown class

### DIFF
--- a/src/patterns/OcAutocomplete.vue
+++ b/src/patterns/OcAutocomplete.vue
@@ -12,6 +12,7 @@
     <div hidden :id="$_ocAutocomplete_boundryId" />
     <div
       class="oc-autocomplete-dropdown"
+      :class="dropdownClass"
       :uk-drop="'mode:click;delay-hide:0;toggle:#' + $_ocAutocomplete_boundryId"
       :id="$_ocAutocomplete_dropdownId"
     >
@@ -124,6 +125,13 @@ export default {
         return item.toLocaleLowerCase().indexOf(queryText.toLocaleLowerCase()) > -1
       },
     },
+    /**
+     * Assigns class to the dropdown
+     */
+    dropdownClass: {
+      type: String,
+      required: false,
+    },
   },
   data() {
     return {
@@ -216,7 +224,7 @@ export default {
       Autocomplete
     </h3>
     <div class="uk-card uk-card-default uk-card-small uk-card-body">
-      <oc-autocomplete v-model="simpleSelection" :items="simpleItems" placeholder="type 'le' for example results" />
+      <oc-autocomplete v-model="simpleSelection" :items="simpleItems" placeholder="type 'le' for example results" dropdownClass="uk-width-1-1" />
       <div class="uk-background-muted uk-padding-small uk-margin-small-top">
         <p class="uk-text-meta">Selected simple item:</p>
         <code>{{ simpleSelection }}</code>


### PR DESCRIPTION
## Description
Added optional prop to assign class to dropdown in autocomplete.

## Motivation
In some cases we need to style the dropdown differently and this way we can simply do it by assigning new class to it and don't need to fallback to theming which could be bad practice in some cases. (e. g. assigning class "uk-width-1-1" to have the same width as input)