### PR TITLE
Fix two 1s in more result text in autocomplete

### DIFF
--- a/src/patterns/OcAutocomplete.vue
+++ b/src/patterns/OcAutocomplete.vue
@@ -39,11 +39,7 @@
           class="oc-autocomplete-suggestion-overflow"
           @click="expanded = true"
         >
-          {{ $_ocAutocomplete_matchesOverflowing }}
-          <span v-if="$_ocAutocomplete_matchesOverflowing === 1">{{
-            $_ocAutocomplete_text.oneMoreResult
-          }}</span>
-          <span v-else>{{ $_ocAutocomplete_text.moreResults }}</span>
+          {{ $_ocAutocomplete_matchesOverflowing }} {{ $_ocAutocomplete_text.moreResults }}
         </li>
         <li v-if="itemsLoading" class="oc-autocomplete-suggestion-list-loader">
           <oc-spinner class="oc-autocomplete-spinner" />
@@ -140,6 +136,7 @@ export default {
       input: "",
       highlighted: 0,
       expanded: false,
+      overflowingMatches: this.$_ocAutocomplete_matchesOverflowing,
     }
   },
   mounted() {
@@ -183,7 +180,6 @@ export default {
       let text = {
         spinner: "Loading…",
         moreResults: "more results",
-        oneMoreResult: "1 more result",
       }
 
       return Object.assign(text, this.text)


### PR DESCRIPTION
## Description
Removed "1 more result" key from autocomplete and added overflowingMatches key to data of component.

## Motivation
With the power of gettext in Phoenix we don't need two different keys for the text "more results" since it can handle plural cases. For this we need to get number of overflowing matches. To access it better in Phoenix, I think it makes sense to make it as a key in data of the component - developers then don't need to access this value with `$_ocAutocomplete_matchesOverflowing` but simply with `data.overflowingMatches` => seems nicer to me.

## Related issue
- Fixes https://github.com/owncloud/phoenix/issues/1511