### PR TITLE
Borderless buttons + using a star inside of it

### DIFF
--- a/src/elements/OCStar.vue
+++ b/src/elements/OCStar.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="oc-star">
-    <oc-icon v-show="shining" class="oc-star-shining" name="star" />
-    <oc-icon v-show="!shining" class="oc-star-dimm" name="star_border" />
+    <oc-icon v-if="shining" class="oc-star-shining" name="star" />
+    <oc-icon v-if="!shining" class="oc-star-dimm" name="star_border" />
   </div>
 </template>
 <script>
@@ -38,6 +38,18 @@ export default {
       A shining star
     </h3>
     <oc-star shining/>
+    <h3 class="uk-heading-divider">
+      Clickable star inside a borderless button
+    </h3>
+    <oc-button variation="link">
+      <oc-star />
+    </oc-button>
+    <h3 class="uk-heading-divider">
+      Clickable shining star inside a borderless button
+    </h3>
+    <oc-button variation="link">
+      <oc-star shining/>
+    </oc-button>
   </section>
 </div>
 ```

--- a/src/elements/OcButton.vue
+++ b/src/elements/OcButton.vue
@@ -103,7 +103,7 @@ export default {
       type: String,
       default: "default",
       validator: value => {
-        return value.match(/(default|primary|secondary|danger)/)
+        return value.match(/(default|primary|secondary|danger|link)/)
       },
     },
     /**
@@ -157,6 +157,7 @@ export default {
       <oc-button variation="primary">Primary Button</oc-button>
       <oc-button variation="secondary">Secondary Button</oc-button>
       <oc-button variation="danger" icon="delete">Danger Button</oc-button>
+      <oc-button variation="link" icon="delete">Borderless Button</oc-button>
       <oc-button disabled>Disabled Button</oc-button>
 
       <h3 class="uk-heading-divider">

--- a/src/styles/theme/oc-button.scss
+++ b/src/styles/theme/oc-button.scss
@@ -46,3 +46,10 @@
     }
   }
 }
+
+.oc-button.uk-button-link {
+  // compensate the absence of border and padding
+  .oc-icon + span {
+    margin-left: $global-margin + 31px; // FIXME: what token to use for that missing padding + border ?
+  }
+}


### PR DESCRIPTION
Allow the "link" variation on oc-button for borderless buttons. Note
that buttons are needed for accessibility tools.
Fix oc-star to not render two spans as it would trigger the CSS rule
".oc-button .oc-icon + span" for the second span which would add an
unwanted left margin.

This is for https://github.com/owncloud/phoenix/issues/1645.
