### PR TITLE
Add accessibility documentation and attributes for OcSpinner

### DIFF
--- a/src/elements/OcSpinner.vue
+++ b/src/elements/OcSpinner.vue
@@ -1,10 +1,20 @@
 <template>
-  <div :uk-spinner="'ratio:' + ratio" :aria-label="ariaLabel"></div>
+  <div :uk-spinner="'ratio:' + ratio" :aria-label="ariaLabel" tabindex="-1" role="img"></div>
 </template>
 
 <script>
 /**
  * Remote actions can take an undefined portion of time. The spinner gives feedback to the users about an actions being processed.
+ *
+ * ## Accessibility
+ * ### Making spinners accessible for screen readers
+ *
+ * 1. Making them (only!) programmatically focusable with `tabindex="-1"`. **This is already included in the component.**
+ * 2. Giving them the [ARIA role](https://developers.google.com/web/fundamentals/accessibility/semantics-aria) of "img" (image) to change the semantics of the spinner element from something meaningless (div) to something meaningful (image). **This is already included in the component.**
+ * 3. Giving them an accessible name ([explainer for the term](https://developer.paciellogroup.com/blog/2017/04/what-is-an-accessible-name/)) via aria-label/the ariaLabel prop. An element that has an accessible name, but no role is ignored by assistive technology
+ * 4. During an action of the application that shows the spinner to visual users, the spinner should programmatically receive focus (see 1.), so that the accessible name of it (default: Loading, see 2.) is read out by screen reader software. After completion of the loading process the focus should be sent to a reasonable place of the newly loaded content.
+ *
+ *
  */
 export default {
   name: "oc-spinner",
@@ -12,10 +22,11 @@ export default {
   release: "1.0.0",
   props: {
     /**
-     * Descriptive text to be read to screen-readers.
+     * Descriptive text to be read to screen-readers, required.
      */
     ariaLabel: {
       type: String,
+      required: true,
       default: "Loading",
     },
     /**


### PR DESCRIPTION
This PR/commit adds:
* role and tabindex attributes to the spinner component
* makes the ariaLabel prop required
* The reasoning behind it, in form of documentation as an example of the accessible use of this component