### PR TITLE
Scaffold accessibility documentation for OcNotification/Message components

### DIFF
--- a/src/elements/OCNotificationMessage.vue
+++ b/src/elements/OCNotificationMessage.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="oc-alert" :class="$_ocNotificationMessage_classes">
     <oc-icon :variation="status" size="large" name="info" class="uk-margin-small-right"></oc-icon>
-    <div class="uk-flex uk-flex-wrap uk-flex-middle uk-flex-1 uk-margin-right">
+    <div
+      class="uk-flex uk-flex-wrap uk-flex-middle uk-flex-1 uk-margin-right"
+      :role="status === 'danger' ? 'alert' : 'status'"
+      :aria-live="status === 'danger' ? 'assertive' : 'polite'"
+    >
       <div class="oc-notification-message-title">
         {{ title }}
       </div>
@@ -10,10 +14,11 @@
       </div>
     </div>
     <oc-icon
+      aria-label="Close"
       :variation="status"
       name="close"
       class="uk-position-top-right uk-margin-small-top uk-margin-small-right oc-alert-close-icon"
-      type="a"
+      type="button"
       @click="$_ocNotificationMessage_close"
     ></oc-icon>
   </div>

--- a/src/elements/OCNotifications.vue
+++ b/src/elements/OCNotifications.vue
@@ -7,7 +7,12 @@
 /**
  * Notifications are used to inform users about errors, warnings and as confirmations for their actions.
  *
- * The default slot can be filled with [oc-notification-message](#/Elements/oc-notification-message) elements
+ * The default slot can be filled with [oc-notification-message](#/Elements/oc-notification-message) elements.
+ *
+ * ## Accessibility
+ *
+ * ### Notifications for screen reader users
+ * This component uses so called live regions in order to announce its content to screen readers once the notification appeared (this is not the normal modus operandi for screen readers, since their reading order is usually the DOM order – when the user does not take shortcuts). There are two types of live regions: `aria-live="polite"` (equivalent to `role="status"`) and `aria-live="assertive"` (equivalent to `role="alert"`). The latter directly interrupts the current output of the screen reader, the former waits until the current output is finished and reads the announcement afterwards. Since 'assertive' should be used sparingly, only `<oc-notfication-message>`'s "danger" status prop value uses `aria-live="assertive"` (and `role="alert"`). Using `aria-live` and `role="assertive|status"` simultaneously is for compatibility reasons regarding different browser and assistive technology pairings.
  */
 export default {
   name: "oc-notifications",

--- a/src/elements/OcIcon.vue
+++ b/src/elements/OcIcon.vue
@@ -2,7 +2,7 @@
   <component
     :is="type"
     :aria-label="ariaLabel"
-    :class="['oc-icon', prefix(size), prefix(variation)]"
+    :class="[{ 'oc-button-reset': type === 'button' }, 'oc-icon', prefix(size), prefix(variation)]"
     v-html="svg"
     @click="$_ocIcon_click"
   />

--- a/src/styles/theme/helper.scss
+++ b/src/styles/theme/helper.scss
@@ -9,3 +9,11 @@
 .oc-visually-hidden {
   @include visually-hidden;
 }
+
+.oc-button-reset {
+  @extend .uk-padding-remove;
+  -webkit-appearance: none;
+  border: none;
+  background: none;
+  font: inherit;
+}


### PR DESCRIPTION
# What's in this PR
* New: added `aria-live` and `role` attributes to the part of the notification container that has text inside it
* New: The amount of interrupting the screen reader (assertive, polite) is indirectly controllable with `<oc-notification-message>`'s `status`: Only "danger" creates an assertive screen reader notification that interrupts the screen reader output
* Changed: The close button is now an actual button (instead of link)
* Changed: The close button has an accessible name of "Close" 
* Added: Documentation 