### PR TITLE
Adjust appbar to a variable height

### DIFF
--- a/src/styles/theme/oc-app-bar.scss
+++ b/src/styles/theme/oc-app-bar.scss
@@ -2,5 +2,5 @@
   @extend .uk-padding-small;
   @extend .uk-background-muted;
 
-  height: $global-control-height;
+  min-height: $global-control-height;
 }


### PR DESCRIPTION
Adjust a min-height instead of a fixed height to all app bars. This is needed on narrow screens

![Bildschirmfoto von »2019-10-20 14-59-27«](https://user-images.githubusercontent.com/2546997/67159876-b87f7100-f34a-11e9-8704-e2df1ffaaab7.png)
![Bildschirmfoto von »2019-10-20 14-59-35«](https://user-images.githubusercontent.com/2546997/67159877-b87f7100-f34a-11e9-9479-fef23322ca06.png)
