### PR TITLE
Add OcActionDrop and OcDisclosure dropdown components...

### DIFF
--- a/src/elements/OcActionDrop.vue
+++ b/src/elements/OcActionDrop.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="oc-dropdown-wrapper" ref="menu" @keyup.esc="closeHandler(true)">
+    <button
+      :aria-expanded="isOpen.toString()"
+      :class="$_ocButton_buttonClass"
+      ref="button"
+      aria-haspopup="true"
+      @click="toggleDropdown"
+      @keydown.enter.prevent="openMenuAndFocus(0)"
+      @keydown.space.prevent="openMenuAndFocus(0)"
+      @keydown.down.prevent="openMenuAndFocus(0)"
+      @keydown.up.prevent="openMenuAndFocus(-1)"
+    >
+      <slot name="button"></slot>
+    </button>
+    <div
+      class="uk-card-default oc-dropdown-menu"
+      role="menu"
+      ref="dropdown"
+      :hidden="!isOpen"
+      @click="closeHandler"
+      @keydown.down.prevent="focusNext"
+      @keydown.up.prevent="focusPrev"
+    >
+      <slot name="actions"></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+/**
+ * Action dropdowns are meant to be used for dropdown menus that are emulating desktop app menus. That means: only consist of items that change state in the app, or open modal dialogs, for example. For using links, inputs, etc. in dropdowns use the disclosure widget pattern (OcDisclosureDrop).
+ *
+ * ## Accessibility
+ *
+ * ### DOM structure
+ * For keyboard and screen reader focus reasons the dropdown's container must follow the menu button directly in the DOM.
+ *
+ * ### Aria roles
+ * OcActionDrop uses the [ARIA Authoring Practices' action menu pattern](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions.html). The dropdown itself has `role="menu"`, its children need to have `role="menuitem"`. The triggering button has the attribute `aria-haspopup="true", which indicates to assitive technology that it opens an action menu. When a screen reader discovers an action menu (and supports the concept of different input modes, like NVDA and JAWS) it switches to application mode.
+ *
+ * ### Allowed content for the dropdown
+ * Quote from [https://accessibility.dev/challenges-mega-menus-standard-menus-make-accessible/](https://accessibility.dev/challenges-mega-menus-standard-menus-make-accessible/):
+ *
+ * > The use of ARIA Menu roles prohibits the inclusion of any non-menu active element roles within the same structure.
+ *
+ * > Since the only focusable elements allowed within an ARIA Menu are those that include role=”menu”, role=”menubar”, role=”menuitem”, role=”menuitemcheckbox”, or role=”menuitemradio”, the embedding of any other active element types such as links, buttons, or other form fields will lead to significant accessibility issues for non-sighted screen reader users when attempting to interact with the menu.
+ The use of ARIA Menu roles causes specific menu related events to be fired in the accessibility tree.
+ *
+ * ### Expected keyboard behaviour when using action menu pattern
+ * The action menu has a certain keyboard behaviour that is expected of being implemented ([see keyboard support table](https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-actions.html#kbd_label)).
+ *
+ * ### Use this pattern sparingly
+ * `role="application"`, either directly or in form of an action menu widget like OcActionDrop should be used sparingly and should be limited to single components, since it changes the screen reader's usual keyboard shortcut pattern ([Learn more about screen reader interaction modes](https://tink.uk/understanding-screen-reader-interaction-modes/)).
+ *
+ * ### Allowed dropdown contents
+ * Only menuitems are allowed in an action menu (everything else will be ignored by screen readers, be it focusable or not). Make sure to make the menuitems focusable themselves by adding `tabindex="0"` to them (see code example below).
+ *
+ * ### The lack of `aria-controls`
+ * While the authoring practices linked above advises to use `aria-controls` to create a programmatic relation between button and dropdown in reality screen reader support is close to non-existent. As of Fall 2019, only JAWS supports it, but has it disabled by default. The relation between trigger and dropdown should be communicated with the proximity of both in the DOM (see above).
+ *
+ * */
+export default {
+  name: "oc-action-drop",
+  status: "review",
+  release: "1.0.0",
+  data: () => {
+    return {
+      isOpen: false,
+      focusableElements: "button, [tabindex='0']",
+      focusables: null,
+      focusedMenuItem: null,
+    }
+  },
+  props: {
+    /**
+     * Supplies button variation to give additional meaning.
+     * `primary, secondary, danger`
+     */
+    buttonVariation: {
+      type: String,
+      default: "default",
+      validator: value => {
+        return value.match(/(default|primary|secondary|danger)/)
+      },
+    },
+  },
+  computed: {
+    $_ocButton_buttonClass() {
+      let classes = ["oc-button"]
+      if (this.buttonVariation) classes.push(`uk-button-${this.buttonVariation}`)
+
+      return classes
+    },
+  },
+  methods: {
+    toggleDropdown() {
+      this.isOpen = !this.isOpen
+    },
+    // Clicks everywhere outside the menu closes it
+    documentClick(e) {
+      let el = this.$refs.menu
+      let target = e.target
+      if (el !== target && !el.contains(target)) {
+        this.closeHandler()
+      }
+    },
+    closeHandler(sendFocusBackToButton) {
+      this.isOpen = false
+
+      if (sendFocusBackToButton) {
+        this.$refs.button.focus()
+      }
+    },
+    openMenuAndFocus(index) {
+      this.isOpen = true
+      this.focusedMenuItem = index === -1 ? this.focusables.length - 1 : index
+      this.setMenuItemFocus(this.focusedMenuItem)
+    },
+    focusNext() {
+      if (this.focusedMenuItem + 1 >= this.focusables.length) {
+        this.focusedMenuItem = 0
+      } else {
+        this.focusedMenuItem = this.focusedMenuItem + 1
+      }
+      this.setMenuItemFocus(this.focusedMenuItem)
+    },
+    focusPrev() {
+      if (this.focusedMenuItem === 0) {
+        this.focusedMenuItem = this.focusables.length - 1
+      } else {
+        this.focusedMenuItem = this.focusedMenuItem - 1
+      }
+      this.setMenuItemFocus(this.focusedMenuItem)
+    },
+    setMenuItemFocus(index) {
+      setTimeout(() => {
+        this.focusables[index].focus()
+      }, 0)
+    },
+  },
+  created() {
+    // Add a general event listener to catch outside clicks
+    document.addEventListener("click", this.documentClick)
+  },
+  destroyed: function() {
+    // Remove the general event listener to catch outside clicks
+    document.removeEventListener("click", this.documentClick)
+  },
+  mounted() {
+    // Add ESC key event listener
+    window.addEventListener("keyup", e => {
+      if (e.key === "Escape") {
+        this.closeHandler()
+      }
+    })
+  },
+  updated: function() {
+    this.focusables = this.$refs.dropdown.querySelectorAll(this.focusableElements)
+  },
+}
+</script>
+
+<docs>
+```jsx
+    <oc-action-drop button-variation="primary">
+        <template v-slot:button>Action</template>
+        <template v-slot:actions>
+            <div tabindex="0" role="menuitem">Action 1</div>
+            <div tabindex="0" role="menuitem">Action 2</div>
+        </template>
+    </oc-action-drop><oc-action-drop button-variation="default">
+        <template v-slot:button>Action</template>
+        <template v-slot:actions>
+            <div tabindex="0" role="menuitem">Action 3</div>
+            <div tabindex="0" role="menuitem">Action 4</div>
+        </template>
+    </oc-action-drop>
+```
+</docs>

--- a/src/elements/OcDisclosureDrop.vue
+++ b/src/elements/OcDisclosureDrop.vue
@@ -1,0 +1,122 @@
+<template>
+  <div class="oc-dropdown-wrapper" ref="menu" @keyup.esc="closeHandler(true)">
+    <button
+      :aria-expanded="isOpen.toString()"
+      :class="$_ocButton_buttonClass"
+      ref="button"
+      @click="toggleDropdown"
+    >
+      <slot name="button"></slot>
+    </button>
+    <div class="uk-card-default oc-dropdown-menu" ref="dropdown" :hidden="!isOpen">
+      <slot name="content"></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+/**
+ * [The concept of a disclosure widget](https://www.w3.org/TR/wai-aria-practices-1.1/#disclosure) is a very basic one in terms of accessibility – you have a control that regulates if another container can be perceived or not. Furthermore, the controls communicates the state of the container to screen readers.
+ *
+ * An example for the usage of OcDisclosureDrop would be phoenix's filter button in the header. By interaction with the button you can control the visibility of the filters (namely checkboxes and the file filter search input). Generally speaking: The use cases for OcActionDrop are scarce, since its allowed contents are very limited (actionable items with `role="menuitem"`). If you are in doubt while building a dropdown menu component, choose OcDisclosureDrop.
+ *
+ * ## Accessibility
+ *
+ * ### When to use
+ * OcDisclosureDrop is useful for situations where you plan to hide/show content, links, form elements, media – in short: everything but a **pure** set of menu actions (for this, use OcActionDrop).
+ *
+ * ### DOM structure
+ * For keyboard and screen reader focus reasons the dropdown's container must follow the button directly in the DOM. Since other concepts of communicating the relation between button and its controlled containers are flawed or not supported by screen readers (`aria-controls`) the only way to show this relation is proximity in the DOM.
+ *
+ * ### Keyboard usage
+ * In comparison to OcActionDrop there is no need for special keyboard usage patterns or even programmatic focus management in disclosure widgets. When the dropdown's state is open, its focusable contents become part of the `tabindex`. If the state is closed, they are removed from it. The fact that button and controlled container are adjacent in the DOM makes sure that the next tab stop after the button after expanding is the first focusable element inside the container.
+ *
+ * */
+export default {
+  name: "oc-disclosure-drop",
+  status: "review",
+  release: "1.0.0",
+  data: () => {
+    return {
+      isOpen: false,
+    }
+  },
+  props: {
+    /**
+     * Supplies button variation to give additional meaning.
+     * `primary, secondary, danger`
+     */
+    buttonVariation: {
+      type: String,
+      default: "default",
+      validator: value => {
+        return value.match(/(default|primary|secondary|danger)/)
+      },
+    },
+  },
+  computed: {
+    $_ocButton_buttonClass() {
+      let classes = ["oc-button"]
+      if (this.buttonVariation) classes.push(`uk-button-${this.buttonVariation}`)
+
+      return classes
+    },
+  },
+  methods: {
+    toggleDropdown() {
+      this.isOpen = !this.isOpen
+    },
+    // Clicks everywhere outside the menu closes it
+    documentClick(e) {
+      let el = this.$refs.menu
+      let target = e.target
+      if (el !== target && !el.contains(target)) {
+        this.closeHandler()
+      }
+    },
+    escKeyHandler(e) {
+      if (e.key === "Escape") {
+        this.closeHandler()
+      }
+    },
+    closeHandler() {
+      this.isOpen = false
+    },
+  },
+  created() {
+    // Add a general event listener to catch outside clicks
+    document.addEventListener("click", this.documentClick)
+  },
+  destroyed: function() {
+    // Remove the general event listener to catch outside clicks
+    document.removeEventListener("click", this.documentClick)
+  },
+  mounted() {
+    // Add ESC key event listener
+    window.addEventListener("keyup", this.escKeyHandler)
+  },
+  beforeDestroy() {
+    // Remove ESC key event listener
+    window.removeEventListener("keyup", this.escKeyHandler)
+  },
+}
+</script>
+
+<docs>
+    ```jsx
+    <oc-disclosure-drop button-variation="primary">
+        <template v-slot:button>Show / Hide</template>
+        <template v-slot:content>
+            <ul class="uk-list">
+                <li><a href="#0">Link 1</a></li>
+                <li><a href="#0">Link 2</a></li>
+            </ul>
+        </template>
+    </oc-disclosure-drop><oc-disclosure-drop button-variation="default">
+        <template v-slot:button>Show / Hide</template>
+        <template v-slot:content>
+            You could also place text, input elements, images, or other form of media here.
+        </template>
+    </oc-disclosure-drop>
+    ```
+</docs>

--- a/src/styles/_owncloud.scss
+++ b/src/styles/_owncloud.scss
@@ -41,6 +41,7 @@
 @import "theme/oc-app-bar";
 @import "theme/oc-scroll";
 @import "theme/oc-page-title";
+@import "theme/oc-dropdown";
 
 // 4. Import UIkit.
 @import "../../node_modules/uikit/src/scss/uikit-theme.scss";

--- a/src/styles/theme/_oc-dropdown.scss
+++ b/src/styles/theme/_oc-dropdown.scss
@@ -1,0 +1,21 @@
+.oc-dropdown-wrapper {
+  display: inline-block;
+  position: relative;
+}
+
+.oc-dropdown-menu {
+  position: absolute;
+  margin-top: 20px;
+  padding: 20px 20px;
+  z-index: 10;
+  animation: oc-dropdown-open 0.2s ease;
+}
+
+@keyframes oc-dropdown-open {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/src/styles/theme/helper.scss
+++ b/src/styles/theme/helper.scss
@@ -1,3 +1,7 @@
+[hidden] {
+  display: none;
+}
+
 .oc-cursor-pointer {
   cursor: pointer;
 }


### PR DESCRIPTION
...as two accessible alternatives for the OcDrop component.

# What is in this PR?

This PR adds two new components, `OcDisclosureDrop` and `OcActionDrop` which are meant to be substitutes for the `OcDrop` components which has accessibility flaws.

# Why are two seperate components even necessary?

Dropdown and menu are not properly defined words. Sometimes the author/dev just want to make a container (in)visible on click (expample: Phoenix's filter button in the header), sometimes they would supply a list of actions that are comparable to actual operating system menus. Since a web-app aims to deliver an OS-like experience there are occasions where assistive technology should be informed that only actions are waiting within the menu, should be adviced change into and application mode and it should be preannounced that focus is about to be changed programmatically (expample: Phoenix's "New" button in the header). While both components aren't distinguishable on a visual level, both have their specific purposes.

# Why has the disclosure one more aria attributes (like haspopup) and key event listeners?

As documented in the components themselves they follow different patterns (disclosure widget and action menu). Both have a common DOM structure (the container directly follows the button node in the HTML), but `OcActionDrop` communicates to screen readers that they should switch into application mode once the action menu is open. In an action menu, certain keyboard usage patterns are expected (see the component's documentation and [the requirements in theunderlying authoring practice]).

# When should I use the one or the other?

`OcActionDrop` should be used very rarely and also if the dropdown contents are exclusively menuitems/actionitems (please note that as content of an action menu dropdown only nodes with `role="menuitem"` are allowed, and everything else in there, even focusable items, will be hidden from screen readers). But to make menuitems focusable for visual keyboard users, please add `tabindex="0"` to them (see example code and documentation).

# Non-owncloud Examples
## Action menus

### Slack
![Slacks kebap menu](https://user-images.githubusercontent.com/505181/67212409-a110b880-f41c-11e9-88ac-52cd5dee509d.png)

### Gmail
![Gmail's settings menu](https://user-images.githubusercontent.com/505181/67212594-e2a16380-f41c-11e9-923b-3c5a7db7c7a8.png)
