### PR TITLE
Various accessibility improvements regarding labels

### DIFF
--- a/src/elements/OcCheckbox.vue
+++ b/src/elements/OcCheckbox.vue
@@ -1,11 +1,14 @@
 <template>
-  <input
-    class="oc-checkbox"
-    type="checkbox"
-    v-model="checkboxState"
-    @change="$_ocCheckbox_change($event)"
-    @click.stop
-  />
+  <label>
+    <input
+      class="oc-checkbox"
+      type="checkbox"
+      v-model="checkboxState"
+      @change="$_ocCheckbox_change($event)"
+      @click.stop
+    />
+    <span v-text="label" :class="{ 'oc-visually-hidden': labelVisuallyHidden }" />
+  </label>
 </template>
 <script>
 /**
@@ -20,6 +23,22 @@ export default {
      * Data-model
      **/
     value: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    /**
+     * Label of the Checkbox
+     **/
+    label: {
+      type: String,
+      required: true,
+      default: null,
+    },
+    /**
+     * Is the label of the Checkbox visually hidden?
+     **/
+    labelVisuallyHidden: {
       type: Boolean,
       required: false,
       default: false,
@@ -60,10 +79,10 @@ export default {
                 <h3 class="uk-heading-divider">
                     Checkboxes Types
                 </h3>
-                <oc-checkbox />
-                <oc-checkbox v-model="checkState1"/>
+                <oc-checkbox label="Label" />
+                <oc-checkbox v-model="checkState1" label="Label"/>
                 <div @click="parentClick">
-                    <oc-checkbox />
+                    <oc-checkbox label="Label" />
                 </div>
             </section>
 

--- a/src/elements/OcRadio.vue
+++ b/src/elements/OcRadio.vue
@@ -1,14 +1,7 @@
 <template>
   <label class="radio-container">
-    <span class="label">{{ label }}</span>
-    <input
-      type="radio"
-      v-model="model"
-      :value="value"
-      name="radio"
-      :aria-label="label"
-      @change="$_ocRadio_change"
-    />
+    <span class="label" v-text="label" />
+    <input type="radio" v-model="model" :value="value" name="radio" @change="$_ocRadio_change" />
     <span class="checkmark"></span>
   </label>
 </template>
@@ -40,10 +33,11 @@ export default {
       required: false,
     },
     /**
-     * Label of the Radio. Will set aria-label aswell.
+     * Label of the Radio.
      **/
     label: {
       type: String,
+      required: true,
       default: null,
     },
   },

--- a/src/elements/OcSwitch.vue
+++ b/src/elements/OcSwitch.vue
@@ -24,10 +24,11 @@ export default {
       type: [Boolean, Number],
     },
     /**
-     * Label of the switch. Will set aria-label as well.
+     * Accessible name of the switch via aria-label.
      **/
     label: {
       type: String,
+      required: true,
       default: null,
     },
   },

--- a/src/elements/OcTextInput.vue
+++ b/src/elements/OcTextInput.vue
@@ -4,7 +4,7 @@
     :type="type"
     :value="value"
     :placeholder="placeholder"
-    :aria-label="placeholder"
+    :aria-label="label"
     ref="input"
     @input="$_ocTextInput_onInput($event.target.value)"
     @focus="
@@ -19,7 +19,10 @@
 /**
  * Form Inputs are used to allow users to provide text input when the expected
  * input is short. Form Input has a range of options and supports several text
- * formats including numbers. For longer input, use the form `Textarea` element.
+ * formats including numbers. For longer input, use the form `Textarea` element.*
+ *
+ * ## Accessibility
+ * The attributes `placeholder` and `aria-label` have different functions. The first specifies a short hint describing the expected value of an input field/text area, or gives an example (e.g. email@example.com). `aria-label` provides the accessible name of the text input (e.g. "Your address", "Comment",...).
  */
 export default {
   name: "oc-text-input",
@@ -42,6 +45,14 @@ export default {
      * @model
      */
     value: {
+      default: null,
+    },
+    /**
+     * Accessible of the form input field, via aria-label.
+     **/
+    label: {
+      type: String,
+      required: true,
       default: null,
     },
     /**

--- a/src/elements/OcTextarea.vue
+++ b/src/elements/OcTextarea.vue
@@ -6,7 +6,7 @@
     @input="$_ocTextArea_onInput($event.target.value)"
     @focus="$_ocTextArea_onFocus($event.target.value)"
     @keydown="$_ocTextArea_onKeyDown($event)"
-    :aria-label="placeholder"
+    :aria-label="label"
   />
 </template>
 
@@ -15,6 +15,9 @@
  * Textareas are used to allow users to provide text input when the expected
  * input is long. Textarea has a range of options. For shorter input,
  * use the `Input` element.
+ *
+ * ## Accessibility
+ * The attributes `placeholder` and `aria-label` have different functions. The first specifies a short hint describing the expected value of an input field/text area, or gives an example (e.g. email@example.com). `aria-label` provides the accessible name of the textarea (e.g. "Your address", "Comment",...).
  */
 export default {
   name: "oc-textarea",
@@ -33,6 +36,14 @@ export default {
      */
     placeholder: {
       type: String,
+      default: null,
+    },
+    /**
+     * Accessible of the Textarea, via aria-label.
+     **/
+    label: {
+      type: String,
+      required: true,
       default: null,
     },
   },
@@ -82,8 +93,8 @@ export default {
 <docs>
 ```jsx
 <div>
-	<oc-textarea class="uk-margin-small-bottom" placeholder="Write your text" />
-	<oc-textarea disabled value="I am disabled" />
+	<oc-textarea class="uk-margin-small-bottom" placeholder="Write your text" label="Comment" />
+	<oc-textarea disabled value="I am disabled" label="Example" />
 </div>
 ```
 </docs>


### PR DESCRIPTION
# What's in this PR

* Make labels required. Unfortunately there is no way to check for the slot's content in prop validation. Vue Docs: "Note that props are validated before a component instance is created, so instance properties (e.g. data, computed, etc) will not be available inside default or validator functions."
* Distinguish between placeholder and label
* Improve example code with labels
* Prevent explicit and aria-label at the same time