### PR TITLE
Adds new tab component tabbed including child components, for #535

### DIFF
--- a/src/elements/OcTabbed.vue
+++ b/src/elements/OcTabbed.vue
@@ -1,0 +1,138 @@
+<template>
+  <div>
+    <div
+      class="oc-tabbed"
+      role="tablist"
+      ref="tablist"
+      @click="clickHandler"
+      @keydown="keydownHandler"
+    >
+      <slot name="tabs"></slot>
+    </div>
+    <div ref="panellist">
+      <slot name="panels"></slot>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "oc-tabbed",
+  status: "prototype",
+  release: "1.0.0",
+  data() {
+    return {
+      tabs: [],
+      panels: [],
+      activeTab: `tab-${this.initial}`,
+    }
+  },
+  props: {
+    initial: {
+      type: String,
+      required: true,
+      default: null,
+    },
+  },
+  mounted() {
+    for (const slotEl of this.$slots.tabs) {
+      if (slotEl.componentOptions && slotEl.componentOptions.tag === "oc-tabbed-tab") {
+        if (slotEl.componentInstance.$el.disabled) return
+        this.tabs.push(slotEl.componentInstance)
+      }
+    }
+
+    for (const slotEl of this.$slots.panels) {
+      if (slotEl.componentOptions && slotEl.componentOptions.tag === "oc-tabbed-panel") {
+        this.panels.push(slotEl.componentInstance)
+      }
+    }
+
+    this.tabs.forEach((tab, i) => {
+      tab.$el.setAttribute("aria-controls", this.panels[i].id)
+    })
+
+    this.panels.forEach((panel, i) => {
+      panel.$el.setAttribute("aria-labelledby", this.tabs[i].id)
+    })
+
+    this.changeTab(this.activeTab)
+  },
+  methods: {
+    changeTab(tab) {
+      this.$nextTick(() => {
+        const tabEl = this.$refs.tablist.querySelector(`#${tab}`)
+
+        this.panels.forEach(panel => {
+          panel.$el.hidden = true
+        })
+
+        this.$refs.panellist.querySelector(`[aria-labelledby=${tab}]`).hidden = false
+
+        this.$refs.tablist.querySelectorAll("[aria-selected]").forEach(el => {
+          el.removeAttribute("aria-selected")
+          el.setAttribute("tabindex", "-1")
+        })
+
+        tabEl.setAttribute("aria-selected", "true")
+        tabEl.setAttribute("tabindex", "0")
+        tabEl.focus()
+
+        this.activeTab = tab
+        this.$emit("activeTab", tab.replace("tab-", ""))
+        this.$emit("click")
+      })
+    },
+    clickHandler(e) {
+      if (!e.target.attributes["aria-controls"]) return
+      this.changeTab(e.target.id)
+    },
+    keydownHandler: function(e) {
+      const activeElem = this.$refs.tablist.querySelector(`#${this.activeTab}`)
+      const activeIndex = Array.from(this.$refs.tablist.children).indexOf(activeElem)
+      let targetTab
+
+      switch (e.keyCode) {
+        case 37:
+          if (activeIndex - 1 < 0) {
+            targetTab = this.tabs[this.tabs.length - 1]
+          } else {
+            targetTab = this.tabs[activeIndex - 1]
+          }
+          this.changeTab(targetTab.id)
+          break
+        case 39:
+          if (activeIndex + 1 > this.tabs.length - 1) {
+            targetTab = this.tabs[0]
+          } else {
+            targetTab = this.tabs[activeIndex + 1]
+          }
+          this.changeTab(targetTab.id)
+          break
+        default:
+          return
+      }
+    },
+  },
+}
+</script>
+
+<docs>
+    ```jsx
+    <template>
+        <oc-tabbed initial="foo">
+            <template slot="tabs">
+                <oc-tabbed-tab name="foo">Item 1</oc-tabbed-tab>
+                <oc-tabbed-tab name="bar">Item 2</oc-tabbed-tab>
+                <oc-tabbed-tab name="baz">Item 3</oc-tabbed-tab>
+            </template>
+            <template slot="panels">
+                <oc-tabbed-panel name="foo">Panel 1</oc-tabbed-panel>
+                <oc-tabbed-panel name="bar">Panel 2</oc-tabbed-panel>
+                <oc-tabbed-panel name="baz">Panel 3</oc-tabbed-panel>
+            </template>
+        </oc-tabbed>
+    </template>
+
+    ```
+</docs>

--- a/src/elements/OcTabbedPanel.vue
+++ b/src/elements/OcTabbedPanel.vue
@@ -1,0 +1,35 @@
+<template>
+  <div role="tabpanel" :id="id" aria-labelledby>
+    <slot />
+  </div>
+</template>
+<script>
+/**
+ * Create a panel item (for a tab component).
+ */
+export default {
+  name: "oc-tabbed-panel",
+  status: "prototype",
+  release: "1.0.0",
+  data() {
+    return {
+      id: null,
+    }
+  },
+  props: {
+    /**
+     * Name of the panel.
+     */
+    name: {
+      type: String,
+    },
+  },
+  mounted() {
+    this.id = `panel-${this.name}`
+  },
+}
+</script>
+
+<docs>
+  Single panel as part of a tab component, not meant to be used in isolation. Please have a look at the component [oc-tabbed](#/Elements/oc-tabbed) for complete tab component code.
+</docs>

--- a/src/elements/OcTabbedTab.vue
+++ b/src/elements/OcTabbedTab.vue
@@ -1,0 +1,45 @@
+<template>
+  <button role="tab" :id="id" @click="$_ocTabItem_onClick" tabindex="-1" aria-controls>
+    <slot />
+  </button>
+</template>
+<script>
+/**
+ * Create a tab item (for a tab component).
+ */
+export default {
+  name: "oc-tabbed-tab",
+  status: "prototype",
+  release: "1.0.0",
+  data() {
+    return {
+      id: null,
+    }
+  },
+  props: {
+    /**
+     * Name of the tab.
+     */
+    name: {
+      type: String,
+    },
+  },
+  methods: {
+    $_ocTabItem_onClick(val) {
+      /**
+       * Click event
+       * @event click
+       * @type {event}
+       */
+      this.$emit("click", val)
+    },
+  },
+  mounted() {
+    this.id = `tab-${this.name}`
+  },
+}
+</script>
+
+<docs>
+  Single tab as part of a tablist for a tab component, not meant to be used in isolation. Please have a look at the component [oc-tabbed](#/Elements/oc-tabbed) for complete tab component code.
+</docs>

--- a/src/styles/_owncloud.scss
+++ b/src/styles/_owncloud.scss
@@ -41,6 +41,7 @@
 @import "theme/oc-app-bar";
 @import "theme/oc-scroll";
 @import "theme/oc-page-title";
+@import "theme/oc-tabbed";
 
 // 4. Import UIkit.
 @import "../../node_modules/uikit/src/scss/uikit-theme.scss";

--- a/src/styles/theme/_oc-tabbed.scss
+++ b/src/styles/theme/_oc-tabbed.scss
@@ -1,0 +1,35 @@
+.oc-tabbed {
+  position: relative;
+  margin-bottom: 20px;
+
+  &::before {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    border-bottom: 1px solid #ccd4e0;
+  }
+
+  [role="tab"] {
+    @extend .oc-button-reset;
+    display: inline-block;
+    text-align: center;
+    padding: 5px 10px;
+    color: #667fa3;
+    border-bottom: 1px solid transparent;
+    font-size: 0.875rem;
+    text-transform: uppercase;
+    transition: color 0.1s ease-in-out;
+
+    &:focus {
+      background-color: rgba(#002966, 0.25);
+    }
+
+    &[aria-selected="true"] {
+      position: relative;
+      color: #002966;
+      border-color: #002966;
+    }
+  }
+}

--- a/src/styles/theme/helper.scss
+++ b/src/styles/theme/helper.scss
@@ -3,11 +3,15 @@
 }
 
 .oc-button-reset {
-  @extend .uk-padding-remove;
+  padding: 0;
   -webkit-appearance: none;
   background: transparent;
   font: inherit;
   border: none;
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }
 
 .oc-align-self-center {


### PR DESCRIPTION
Establishes:

* New tab component `oc-tabbed`
* New tab-item component `oc-tabbed-tab`
* New panel-item component `oc-tabbed-panel`

Structure according to the briefing by @PVince81 

Keyboard behaviour, ARIA roles, properties and states according to the [Authoring Practice](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.htmll) 

Intention for establishing new components: Trying to avoid to break phoenix by using the `oc-tab-item` namespace since the new component is much more complex than the existing one.