### PR TITLE
Use the correct attribute for size

### DIFF
--- a/src/elements/OCAvatar.vue
+++ b/src/elements/OCAvatar.vue
@@ -2,7 +2,7 @@
   <avatar
     class="oc-avatar"
     :username="userName"
-    :width="width"
+    :size="width"
     :src="src"
     :alt="accessibilityLabel"
     :aria-hidden="accessibilityLabel === ''"


### PR DESCRIPTION
When [switching to vue-avatar](#592) the attribute name is now a different one.