### PR TITLE
Share indicators + new icon colors "active" and "passive"

### DIFF
--- a/src/elements/OcIcon.vue
+++ b/src/elements/OcIcon.vue
@@ -76,7 +76,7 @@ export default {
       type: String,
       default: "system",
       validator: value => {
-        return value.match(/(file-type|system|inverted|danger|success|warning)/)
+        return value.match(/(file-type|system|active|passive|inverted|danger|success|warning)/)
       },
     },
   },
@@ -148,7 +148,7 @@ export default {
 					<oc-icon variation="inverted" name="account_circle"/>
 				</oc-table-cell>
 			</oc-table-row>
-			<oc-table-row v-for="variation in ['danger', 'success', 'warning', 'file-type', 'system']">
+			<oc-table-row v-for="variation in ['danger', 'success', 'warning', 'file-type', 'system', 'active', 'passive']">
 				<oc-table-cell shrink>{{variation}}</oc-table-cell>
 				<oc-table-cell expand>
 					<oc-icon :variation="variation" name="close"/>

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -233,6 +233,7 @@ export default {
                 <oc-checkbox />
               </oc-table-cell>
               <oc-table-cell type="head" class="uk-text-truncate" v-text="'Name'"/>
+              <oc-table-cell shrink type="head" />
               <oc-table-cell shrink type="head" v-text="'Size'"/>
               <oc-table-cell shrink type="head" class="uk-text-nowrap uk-visible@s" v-text="'Modification Time'"/>
               <oc-table-cell shrink type="head" v-text="'Actions'"/>
@@ -243,9 +244,14 @@ export default {
               <oc-table-cell>
                 <oc-checkbox />
               </oc-table-cell>
-              <oc-table-cell>
+              <oc-table-cell class="uk-text-truncate uk-text-meta uk-width-expand">
                 <!-- FIXME dont register a click handler for every file. register it on the table and get the filename from the event -->
                 <oc-file @click="selectFile(file)" :name="file.name" :extension="file.extension" :icon="file.icon"/>
+              </oc-table-cell>
+              <oc-table-cell class="uk-text-muted uk-text-nowrap">
+                <template v-for="icon in file.indicators">
+                  <oc-icon :name="icon.name" size="small" :variation="icon.active ? 'active' : 'passive' " />
+                </template>
               </oc-table-cell>
               <oc-table-cell class="uk-text-muted uk-text-nowrap" v-text=" (++o * 128) + ' Kb'" />
               <oc-table-cell class="uk-text-muted uk-text-nowrap uk-visible@s" v-text=" ++o + ' days ago'" />
@@ -300,10 +306,15 @@ export default {
         rightHidden: true,
         loading: true,
         files: [
-          {name: "Private", extension: "", icon:'folder'},
-          {name: "Project", extension: "", icon:'folder-shared'},
           {name: "Document", extension: "pdf", icon:'application-pdf'},
           {name: "Picture", extension: "png", icon:'image'},
+          {name: "Private", extension: "", icon:'folder'},
+          {name: "Project shared both directly", extension: "", icon:'folder', indicators: [{name:'group', active:true}, {name:'link', active:true}]},
+          {name: "Project shared both from parent", extension: "", icon:'folder', indicators: [{name:'group'}, {name:'link'}]},
+          {name: "Project shared by link directly", extension: "", icon:'folder', indicators: [{name:'link', active:true}]},
+          {name: "Project shared by link through parent", extension: "", icon:'folder', indicators: [{name:'link'}]},
+          {name: "Project received directly", extension: "", icon:'folder', indicators: [{name:'group'}]},
+          {name: "Project received through parent", extension: "", icon:'folder', indicators: [{name:'group'}]},
           {name: "Presentation", extension: "odp", icon:'x-office-presentation'},
           {name: "README", extension: "md", icon:'text'},
           {name: "Spreadsheet", extension: "ods", icon:'x-office-spreadsheet'},

--- a/src/styles/theme/oc-icon.scss
+++ b/src/styles/theme/oc-icon.scss
@@ -39,6 +39,14 @@ $oc-icon-size: 24px;
 
   // Variations
 
+  &-active > svg {
+    fill: $active-icon-color;
+  }
+
+  &-passive > svg {
+    fill: $passive-icon-color;
+  }
+
   &-file-type > svg {
     fill: $filetype-icon-color;
   }

--- a/src/tokens/color.yml
+++ b/src/tokens/color.yml
@@ -31,6 +31,14 @@ props:
     value: "#667fa3"
     category: "icon-colors"
 
+  active-icon-color:
+    value: "#002966"
+    category: "icon-colors"
+
+  passive-icon-color:
+    value: "#cccccc"
+    category: "icon-colors"
+
   system-icon-color:
     value: "#667fa3"
     category: "icon-colors"


### PR DESCRIPTION
<img width="635" alt="image" src="https://user-images.githubusercontent.com/277525/72087023-34fd6c80-3308-11ea-8201-0b0687db9cab.png">

This idea brings all share indicators into a separate column.

## Requirements check
### Level 1

- which resource is shared: see whether column icons are present
- what kind of share ? (user/link): see icon types in column
- is the share applied from a parent instead of directly ? => see reduced opacity
- optional: incoming/outgoing ? icon color

### Level 2

- who has access ?
   - open right sidebar for resource
   - list of collaborators sums up collaborators of parents (+ via jump)
   - list of links sums up links of parents

## TODOs:

- [x] keep column in responsive mode ?
- [x] check if desktop and mobile clients can align with this design ?
- [x] question: feature request for opening sidebar for current folder ?? 