### PR TITLE
Provide placeholder property and bind it into the datepicker

### DIFF
--- a/src/elements/OcDatepicker.vue
+++ b/src/elements/OcDatepicker.vue
@@ -7,6 +7,7 @@
     :phrases="phrases"
     :min-datetime="minDatetime"
     :max-datetime="maxDatetime"
+    :placeholder="placeholder"
     @cancel="$_cancel()"
     @input="$_input()"
   ></datetime>
@@ -53,6 +54,13 @@ export default {
     date: {
       type: String,
       default: moment().format(),
+    },
+    /**
+     * The placeholder value for the form input field.
+     */
+    placeholder: {
+      type: String,
+      default: null,
     },
     /**
      * Popup title.


### PR DESCRIPTION
Implementation for https://github.com/owncloud/owncloud-design-system/issues/617

As the used datepicker component already binds `$attrs` to the input field, it is sufficient to just add a `placeholder` property and bind it to the `datetime` tag. Copied the placeholder property from `OcTextInput` in order to have identical documentation.

Can be tested by running ods and inspecting the input field of a datepicker with placeholder variable.