### PR TITLE
Fix breadcrumb component ellipsis

### DIFF
--- a/src/elements/OcBreadcrumb.vue
+++ b/src/elements/OcBreadcrumb.vue
@@ -38,7 +38,7 @@
  *
  *  - text: mandatory element, holds the text which is to be displayed in the breadcrumb
  *  - to: optional element, the vue router link
- *  -
+ *
  */
 export default {
   name: "oc-breadcrumb",
@@ -80,7 +80,9 @@ export default {
 <docs>
 ```vue
 <template>
-  <oc-breadcrumb :items="items" home></oc-breadcrumb>
+  <section>
+    <oc-breadcrumb :items="items" home></oc-breadcrumb>
+  </section>
 </template>
 <script>
   export default {
@@ -90,7 +92,7 @@ export default {
           {text:'First folder',to:{path:'folder'}},
           {text:'Subfolder', onClick:() => alert('Breadcrumb clicked!')},
           {text:'Deep',to:{path:'folder'}},
-          {text:'Deeper'},
+          {text:'Deeper ellipsize in responsive mode'},
         ]
       }
     }

--- a/src/styles/theme/oc-breadcrumb.scss
+++ b/src/styles/theme/oc-breadcrumb.scss
@@ -4,6 +4,8 @@
 // ========================================================================
 
 .oc-breadcrumb {
+  @extend .uk-overflow-hidden;
+
   &-list {
     @extend .uk-visible\@s;
     @extend .uk-breadcrumb;


### PR DESCRIPTION
Added overflow: hidden on the main element of the oc-breadcrumb to make
sure that it can ellipsize its content in responsive mode.

![image](https://user-images.githubusercontent.com/277525/73559810-16494c00-4456-11ea-8a39-230f6124cf3b.png)

Before this fix it would just overflow.

You can also try this in Phoenix by having long folder names and adding "overflow:hidden" on that element and see the difference.
