### PR TITLE
Set aria-label on oc-spinner in oc-autocomplete

### DIFF
--- a/src/patterns/OcAutocomplete.vue
+++ b/src/patterns/OcAutocomplete.vue
@@ -64,8 +64,8 @@
           >
         </li>
         <li v-if="itemsLoading" class="oc-autocomplete-suggestion-list-loader">
-          <oc-spinner class="oc-autocomplete-spinner" />
-          <span>{{ $_ocAutocomplete_text.spinner }}</span>
+          <oc-spinner :aria-label="$_ocAutocomplete_text.spinner" class="oc-autocomplete-spinner" />
+          <span :aria-hidden="true">{{ $_ocAutocomplete_text.spinner }}</span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
Set missing `aria-label` on oc-spinner in oc-autocomplete. span got an `aria-hidden` because for a screenreader it's sufficient to have the label from the spinner, don't need the same text again in the span.