### PR TITLE
Reset input on selection if fillOnSelection=false

### DIFF
--- a/src/patterns/OcAutocomplete.vue
+++ b/src/patterns/OcAutocomplete.vue
@@ -300,6 +300,7 @@ export default {
           this.input = this.$_ocAutocomplete_getSelectionText(this.highlighted)
         } else {
           this.$_ocAutocomplete_dropdown.hide()
+          this.input = ""
         }
       }
     },


### PR DESCRIPTION
On item selection from the autocomplete dropdown, the input field needs to be either reset or filled with the selected value. Keeping the given input after selection looks like an error state.

We already have the case that the selection gets applied to the input field, when `fillOnSelection` is `true` (default). This PR fixes the other case, i.e. clearing the input field on selection when `fillOnSelection` is `false`.