### PR TITLE
Remove uppercase on buttons

### DIFF
--- a/changelog/unreleased/652
+++ b/changelog/unreleased/652
@@ -1,0 +1,6 @@
+Bugfix: Removed uppercase on buttons
+
+Buttons look nicer without the uppercase which was brought in by default by UIKit.
+
+https://github.com/owncloud/owncloud-design-system/issues/442
+https://github.com/owncloud/owncloud-design-system/pull/652

--- a/src/elements/OcButton.vue
+++ b/src/elements/OcButton.vue
@@ -178,6 +178,7 @@ export default {
       <oc-button variation="secondary">Secondary Button</oc-button>
       <oc-button variation="danger" icon="delete">Danger Button</oc-button>
       <oc-button disabled>Disabled Button</oc-button>
+      <oc-button variation="raw">Raw Button</oc-button>
 
       <h3 class="uk-heading-divider">
         Button sizes

--- a/src/styles/theme/oc-button.scss
+++ b/src/styles/theme/oc-button.scss
@@ -26,6 +26,8 @@
     margin-left: $global-margin;
   }
 
+  text-transform: none !important;
+
   &:not(.uk-button-small):not(.uk-button-large) {
     min-height: $global-control-height;
   }


### PR DESCRIPTION
UIKit is adding text-transform: uppercase on all buttons.
This commit removes it in the standard theme.

Not sure if the theme is the right place though...