### PR TITLE
Removed size for oc-button with raw variation

### DIFF
--- a/changelog/unreleased/654
+++ b/changelog/unreleased/654
@@ -1,0 +1,5 @@
+Bugfix: Removed size for oc-button with raw variation
+
+Raw variation of buttons have no border, so they now also don't have a size enforced to avoid needless white space.
+
+https://github.com/owncloud/owncloud-design-system/issues/654

--- a/src/elements/OcButton.vue
+++ b/src/elements/OcButton.vue
@@ -149,7 +149,7 @@ export default {
 
       if (this.disabled) classes.push("uk-button-default")
 
-      if (this.size) classes.push(`uk-button-${this.size}`)
+      if (this.size && this.variation !== "raw") classes.push(`uk-button-${this.size}`)
 
       return classes
     },

--- a/src/styles/theme/oc-button.scss
+++ b/src/styles/theme/oc-button.scss
@@ -28,7 +28,7 @@
 
   text-transform: none !important;
 
-  &:not(.uk-button-small):not(.uk-button-large) {
+  &:not(.uk-button-small):not(.uk-button-large):not(.uk-button-raw) {
     min-height: $global-control-height;
   }
 


### PR DESCRIPTION
Raw variation of buttons have no border, so they now also don't have a size enforced to avoid needless white space.