### PR TITLE
Make scrollbar styles more consistent

### DIFF
--- a/changelog/unreleased/660
+++ b/changelog/unreleased/660
@@ -1,0 +1,5 @@
+Bugfix: Made scrollbar styles consistent
+
+Scrollbar styles are now more consistent between Chrome and Firefox.
+
+https://github.com/owncloud/owncloud-design-system/pull/660

--- a/src/pages/Files.vue
+++ b/src/pages/Files.vue
@@ -39,7 +39,8 @@ export default {
 <docs>
 ```jsx
 <template>
-  <div style="background-color: white; overflow: auto;"><!-- top container to fill the whole screen/area -->
+  <!-- top container to fill the whole screen/area, but with scrollbars  -->
+  <div id="oc-content" style="background-color: white; overflow: auto; height: 70vh; ">
     <oc-dialog name="OcDialog" title="Not implemented">
       <template slot="content">
         This feature is not implemented yet.
@@ -202,7 +203,6 @@ export default {
           <div class="uk-width-auto">
             <div class="uk-button-group">
               <oc-button variation="primary" id="_new" icon="add" />
-              <oc-button id="_filter" icon="filter_list" />
             </div>
             <oc-drop toggle="#_new" mode="hover" :options="{pos:'bottom-right'}">
               <oc-nav>

--- a/src/styles/theme/main.scss
+++ b/src/styles/theme/main.scss
@@ -9,8 +9,14 @@ body {
   overflow-y: auto;
   overflow-x: hidden;
 
+  scrollbar-width: thin;
+
   &::-webkit-scrollbar {
-    width: 10px;
+    width: 5px;
+  }
+
+  &::-webkit-scrollbar-track-piece {
+    background-color: transparent;
   }
 
   &::-webkit-scrollbar-track {


### PR DESCRIPTION
The Chrome scrollbar is now thinner to look like the Firefox one.

Adjusted Files page to be able to demonstrate the scrollbar styles.

Note: I heard that this would only affect Windows and Linux as Macs already have the proper style.

On my Linux box now the scrollbars look like this:

### Chromium
<img width="635" alt="image" src="https://user-images.githubusercontent.com/277525/75339256-73d38b80-5890-11ea-8b5e-b2a84a4f2a5d.png">

### Firefox
<img width="635" alt="image" src="https://user-images.githubusercontent.com/277525/75339284-80f07a80-5890-11ea-91ff-03cb021147d3.png">

Fixes https://github.com/owncloud/phoenix/issues/3045