### PR TITLE
Reload icon image when its url prop changed

### DIFF
--- a/changelog/unreleased/681
+++ b/changelog/unreleased/681
@@ -1,0 +1,5 @@
+Bugfix: Fixed oc-icon to reload image when url changes
+
+The oc-icon component will now reload its image whenever the url property has been modified
+
+https://github.com/owncloud/owncloud-design-system/pull/681

--- a/src/elements/OcIcon.vue
+++ b/src/elements/OcIcon.vue
@@ -87,18 +87,7 @@ export default {
     }
   },
   mounted() {
-    if (this.url !== undefined) {
-      this.iconUrl = this.url
-      const img = new Image()
-      img.addEventListener("load", () => {
-        this.iconNotLoaded = false
-      })
-      img.addEventListener("error", () => {
-        this.$emit("error")
-        this.iconUrl = ""
-      })
-      img.src = this.iconUrl
-    }
+    this.loadImage()
   },
   methods: {
     prefix(string) {
@@ -107,6 +96,20 @@ export default {
     $_ocIcon_click() {
       this.$emit("click")
     },
+    loadImage () {
+      this.iconUrl = this.url
+      if (this.url !== undefined) {
+        const img = new Image()
+        img.addEventListener("load", () => {
+          this.iconNotLoaded = false
+        })
+        img.addEventListener("error", () => {
+          this.$emit("error")
+          this.iconUrl = ""
+        })
+        img.src = this.iconUrl
+      }
+    }
   },
   computed: {
     $_ocIcon_type() {
@@ -116,6 +119,11 @@ export default {
       return req("./" + this.name + ".svg")
     },
   },
+  watch: {
+    url () {
+      this.loadImage()
+    }
+  }
 }
 </script>
 <style lang="scss"></style>


### PR DESCRIPTION
Instead of loading the icon image from the URL only when mounted, the
component now also supports changing the URL after mounting. The watcher
will trigger a reload of the image whenever the URL property changed.