### PR TITLE
Introduce error and warning message below input

### DIFF
--- a/changelog/unreleased/688
+++ b/changelog/unreleased/688
@@ -1,0 +1,6 @@
+Bugfix: Fixed oc-text-input not appearing in generated docs
+
+The oc-text-input element didn't appear in the generated docs because of a compilation warning.
+
+https://github.com/owncloud/owncloud-design-system/issues/688
+https://github.com/owncloud/owncloud-design-system/pull/690

--- a/changelog/unreleased/689
+++ b/changelog/unreleased/689
@@ -1,0 +1,10 @@
+Change: Render error and warning messages in oc-text-input
+
+The oc-text-input element now has properties for rendering a warning or error message below
+the input field. The input field border receives the respective matching color as well. Also
+it's possible to reserve a fixed vertical space below the input element, so that an appearing
+message doesn't break the layout around the input element.
+
+https://github.com/owncloud/owncloud-design-system/issues/689
+https://github.com/owncloud/owncloud-design-system/pull/690
+

--- a/src/elements/OcTextInput.vue
+++ b/src/elements/OcTextInput.vue
@@ -1,18 +1,25 @@
 <template>
-  <input
-    :class="{ 'oc-text-input': !stopClassPropagation }"
-    :type="type"
-    :value="value"
-    :placeholder="placeholder"
-    :aria-label="label"
-    ref="input"
-    @input="$_ocTextInput_onInput($event.target.value)"
-    @focus="
-      $event.target.select()
-      $_ocTextInput_onFocus($event.target.value)
-    "
-    @keydown="$_ocTextInput_onKeyDown($event)"
-  />
+  <div>
+    <input
+      :aria-label="label"
+      :class="{
+        'oc-text-input': !stopClassPropagation,
+        'oc-text-input-warning': !!warningMessage,
+        'oc-text-input-danger': !!errorMessage,
+      }"
+      :placeholder="placeholder"
+      :type="type"
+      :value="value"
+      @input="$_ocTextInput_onInput($event.target.value)"
+      @focus="$_ocTextInput_onFocus($event.target)"
+      @keydown="$_ocTextInput_onKeyDown($event)"
+      ref="input"
+    />
+    <div class="oc-text-input-message" v-if="$_ocTextInput_showMessageLine">
+      <span v-if="!!warningMessage" class="oc-text-input-warning">{{ warningMessage }}</span>
+      <span v-if="!!errorMessage" class="oc-text-input-danger">{{ errorMessage }}</span>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -69,6 +76,33 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * A warning message which is shown below the input.
+     */
+    warningMessage: {
+      type: String,
+      default: null,
+    },
+    /**
+     * An error message which is shown below the input.
+     */
+    errorMessage: {
+      type: String,
+      default: null,
+    },
+    /**
+     * Whether or not vertical space below the input should be reserved for a one line message,
+     * so that content actually appearing there doesn't shift the layout.
+     */
+    fixMessageLine: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    $_ocTextInput_showMessageLine() {
+      return this.fixMessageLine || !!this.warningMessage || !!this.errorMessage
+    },
   },
   methods: {
     /**
@@ -85,12 +119,13 @@ export default {
        **/
       this.$emit("input", value)
     },
-    $_ocTextInput_onFocus(value) {
+    $_ocTextInput_onFocus(target) {
+      target.select()
       /**
        * Focus event - emitted as soon as the input field is focused
        * @type {event}
        **/
-      this.$emit("focus", value)
+      this.$emit("focus", target.value)
     },
     $_ocTextInput_onKeyDown(e) {
       if (e.keyCode === 13) {
@@ -110,6 +145,7 @@ export default {
   },
 }
 </script>
+
 <docs>
     ```jsx
     <template>
@@ -134,14 +170,43 @@ export default {
             <oc-text-input label="Focus field" placeholder="Will you focus on me?" ref="inputForFocus"/>
             <oc-button @click="_focusAndSelect">Focus and select input below</oc-button>
             <oc-text-input label="Select field" value="Will you select this existing text?" ref="inputForFocusSelect"/>
+            <h3 class="uk-heading-divider">
+                Messages
+            </h3>
+            <oc-text-input
+                    label="Input with error and warning messages with reserved space below"
+                    class="uk-margin-small-bottom"
+                    placeholder="Text produces error on empty value and warning on trailing whitespace"
+                    v-model="valueForMessages"
+                    :error-message="errorMessage"
+                    :warning-message="warningMessage"
+                    :fix-message-line="true"
+            />
+            <oc-text-input
+                    label="Input with error and warning messages without reserved space below"
+                    class="uk-margin-small-bottom"
+                    placeholder="Text produces error on empty value and warning on trailing whitespace"
+                    v-model="valueForMessages"
+                    :error-message="errorMessage"
+                    :warning-message="warningMessage"
+            />
         </section>
     </template>
     <script>
         export default {
             data: () => {
                 return {
-                    inputValue: 'initial'
+                    inputValue: 'initial',
+                    valueForMessages: '',
                 }
+            },
+            computed: {
+              errorMessage() {
+                return this.valueForMessages.length === 0 ? 'Value is required.' : ''
+              },
+              warningMessage() {
+                return this.valueForMessages.endsWith(' ') ? 'Trailing whitespace should be avoided.' : ''
+              }
             },
             methods: {
                 _focus() {

--- a/src/styles/theme/oc-text-input.scss
+++ b/src/styles/theme/oc-text-input.scss
@@ -14,3 +14,19 @@
 .oc-text-input {
   @extend .uk-input;
 }
+.oc-text-input-warning,
+.oc-text-input-warning:focus {
+  color: $warning-background !important;
+  border-color: $warning-background !important;
+}
+.oc-text-input-danger,
+.oc-text-input-danger:focus {
+  color: $danger-background !important;
+  border-color: $danger-background !important;
+}
+.oc-text-input-message {
+  @extend .uk-flex;
+  @extend .uk-flex-middle;
+  @extend .uk-margin-xsmall-top;
+  min-height: $global-font-size * 1.5;
+}


### PR DESCRIPTION
This PR introduces properties for the `oc-text-input` component, allowing to provide an error message or warning message, that will then be shown below the input field. In addition to that, the space below the input field can be set to a min height, so that the space is always reserved (at least for one line) no matter if an error or warning message is currently visible or not. Property is off by default, so that the input doesn't take up more space than it would have needed in the first place.
Issue is: https://github.com/owncloud/owncloud-design-system/issues/689

Also I noticed that the component was not present in the generated docs. This was due to a compilation warning in `@focus` of the input. Fixed it by moving the two commands into the method instead of having two commands inline in `@focus`.
Issue is: https://github.com/owncloud/owncloud-design-system/issues/688

### Error message
![Bildschirmfoto 2020-03-24 um 17 26 40](https://user-images.githubusercontent.com/3532843/77451592-2990ec00-6df5-11ea-8e64-88a8f9e9ce3a.png)

### Warning message
![Bildschirmfoto 2020-03-24 um 17 27 01](https://user-images.githubusercontent.com/3532843/77451598-2ac21900-6df5-11ea-946a-fd2273a2f344.png)

### No message
![Bildschirmfoto 2020-03-24 um 17 26 52](https://user-images.githubusercontent.com/3532843/77451597-2ac21900-6df5-11ea-8fca-b3f9568a2529.png)
You can notice that the upper input has a fixed vertical space below the input, so although no message is there, the vertical distance to the next input stays the same. The lower input doesn't have fixed vertical space below, so the space to the dark blue area shrinks when there is no message.