### PR TITLE
Fix wrapped text input

### DIFF
--- a/changelog/unreleased/704
+++ b/changelog/unreleased/704
@@ -1,0 +1,8 @@
+Bugfix: Reverted oc-text-input and added oc-form-input instead
+
+As the `oc-text-input` component should stay as simple as possible, being only an input element,
+we have extracted the validation message features into a new pattern component, wrapping
+`oc-text-input` and a message. All properties and listeners applied to `oc-form-input` will be
+forwarded into the internally used `oc-text-input` component.
+
+https://github.com/owncloud/owncloud-design-system/pull/704

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     },
     "parserOptions": {
       "sourceType": "module",
-      "ecmaVersion": 8,
+      "ecmaVersion": 9,
       "ecmaFeatures": {
         "jsx": true
       }

--- a/src/elements/OcTextInput.vue
+++ b/src/elements/OcTextInput.vue
@@ -1,11 +1,10 @@
 <template>
-  <div>
     <input
       :aria-label="label"
       :class="{
         'oc-text-input': !stopClassPropagation,
-        'oc-text-input-warning': !!warningMessage,
-        'oc-text-input-danger': !!errorMessage,
+        'oc-text-input-warning': hasWarning,
+        'oc-text-input-danger': hasError,
       }"
       :placeholder="placeholder"
       :type="type"
@@ -15,11 +14,6 @@
       @keydown="$_ocTextInput_onKeyDown($event)"
       ref="input"
     />
-    <div class="oc-text-input-message" v-if="$_ocTextInput_showMessageLine">
-      <span v-if="!!warningMessage" class="oc-text-input-warning">{{ warningMessage }}</span>
-      <span v-if="!!errorMessage" class="oc-text-input-danger">{{ errorMessage }}</span>
-    </div>
-  </div>
 </template>
 
 <script>
@@ -77,32 +71,19 @@ export default {
       default: false,
     },
     /**
-     * A warning message which is shown below the input.
+     * Whether or not to highlight a warning state.
      */
-    warningMessage: {
-      type: String,
-      default: null,
-    },
-    /**
-     * An error message which is shown below the input.
-     */
-    errorMessage: {
-      type: String,
-      default: null,
-    },
-    /**
-     * Whether or not vertical space below the input should be reserved for a one line message,
-     * so that content actually appearing there doesn't shift the layout.
-     */
-    fixMessageLine: {
+    hasWarning: {
       type: Boolean,
       default: false,
     },
-  },
-  computed: {
-    $_ocTextInput_showMessageLine() {
-      return this.fixMessageLine || !!this.warningMessage || !!this.errorMessage
-    },
+    /**
+     * Whether or not to highlight an error state.
+     */
+    hasError: {
+      type: Boolean,
+      default: false,
+    }
   },
   methods: {
     /**
@@ -171,24 +152,15 @@ export default {
             <oc-button @click="_focusAndSelect">Focus and select input below</oc-button>
             <oc-text-input label="Select field" value="Will you select this existing text?" ref="inputForFocusSelect"/>
             <h3 class="uk-heading-divider">
-                Messages
+                States
             </h3>
             <oc-text-input
-                    label="Input with error and warning messages with reserved space below"
-                    class="uk-margin-small-bottom"
-                    placeholder="Text produces error on empty value and warning on trailing whitespace"
+                    label="Input with highlighted error and warning state"
+                    placeholder="Text has error state on empty value and warning state on trailing whitespace"
                     v-model="valueForMessages"
-                    :error-message="errorMessage"
-                    :warning-message="warningMessage"
+                    :has-error="hasError"
+                    :has-warning="hasWarning"
                     :fix-message-line="true"
-            />
-            <oc-text-input
-                    label="Input with error and warning messages without reserved space below"
-                    class="uk-margin-small-bottom"
-                    placeholder="Text produces error on empty value and warning on trailing whitespace"
-                    v-model="valueForMessages"
-                    :error-message="errorMessage"
-                    :warning-message="warningMessage"
             />
         </section>
     </template>
@@ -201,11 +173,11 @@ export default {
                 }
             },
             computed: {
-              errorMessage() {
-                return this.valueForMessages.length === 0 ? 'Value is required.' : ''
+              hasError() {
+                return this.valueForMessages.length === 0
               },
-              warningMessage() {
-                return this.valueForMessages.endsWith(' ') ? 'Trailing whitespace should be avoided.' : ''
+              hasWarning() {
+                return this.valueForMessages.endsWith(' ')
               }
             },
             methods: {

--- a/src/patterns/OcFormInput.vue
+++ b/src/patterns/OcFormInput.vue
@@ -1,0 +1,191 @@
+<template>
+  <div>
+    <oc-text-input
+      v-bind="$_ocFormInput_inputBindings"
+      v-on="$listeners"
+      :has-error="!!errorMessage"
+      :has-warning="!!warningMessage"
+    />
+    <div class="oc-form-input-message" v-if="$_ocFormInput_showMessageLine">
+      <span v-if="!!warningMessage" class="oc-form-input-warning">{{ warningMessage }}</span>
+      <span v-if="!!errorMessage" class="oc-form-input-danger">{{ errorMessage }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import OcTextInput from "../elements/OcTextInput"
+/**
+ * Form Inputs are used to allow users to provide text input when the expected
+ * input is short. Form Input has a range of options and supports several text
+ * formats including numbers. For longer input, use the form `Textarea` element.
+ *
+ * All properties will be handed through to the inner OcTextInput component. The purpose
+ * of this component is, to be able to show validation messages below the input, while
+ * utilizing all functionality from OcTextInput.
+ *
+ * ## Accessibility
+ * The attributes `placeholder` and `aria-label` have different functions. The first specifies a short hint describing the expected value of an input field/text area, or gives an example (e.g. email@example.com). `aria-label` provides the accessible name of the text input (e.g. "Your address", "Comment",...).
+ */
+export default {
+  name: "oc-form-input",
+  components: { OcTextInput },
+  status: "review",
+  release: "1.0.0",
+  inheritAttrs: false,
+  props: {
+    /**
+     * The type of the form input field.
+     * `text, number, email, password`
+     */
+    type: {
+      type: String,
+      default: "text",
+      validator: value => {
+        return value.match(/(text|number|email|password)/)
+      },
+    },
+    /**
+     * Text value of the form input field.
+     * @model
+     */
+    value: {
+      default: null,
+    },
+    /**
+     * Accessible of the form input field, via aria-label.
+     **/
+    label: {
+      type: String,
+      required: true,
+      default: null,
+    },
+    /**
+     * The placeholder value for the form input field.
+     */
+    placeholder: {
+      type: String,
+      default: null,
+    },
+    /**
+     * Don't add the element class to this element.
+     */
+    stopClassPropagation: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * A warning message which is shown below the input.
+     */
+    warningMessage: {
+      type: String,
+      default: null,
+    },
+    /**
+     * An error message which is shown below the input.
+     */
+    errorMessage: {
+      type: String,
+      default: null,
+    },
+    /**
+     * Whether or not vertical space below the input should be reserved for a one line message,
+     * so that content actually appearing there doesn't shift the layout.
+     */
+    fixMessageLine: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    $_ocFormInput_inputBindings() {
+      const result = {
+        ...this.$attrs,
+        ...this.$props
+      }
+      delete result.warningMessage
+      delete result.errorMessage
+      delete result.fixMessageLine
+      return result
+    },
+    $_ocFormInput_showMessageLine() {
+      return this.fixMessageLine || !!this.warningMessage || !!this.errorMessage
+    },
+  }
+}
+</script>
+
+<docs>
+    ```jsx
+    <template>
+        <section>
+            <h3 class="uk-heading-divider">
+                Input Types
+            </h3>
+            <oc-form-input class="uk-margin-small-bottom" label="Text" placeholder="Write your text"/>
+            <oc-form-input class="uk-margin-small-bottom" disabled label="Disabled" value="I am disabled"/>
+            <oc-form-input class="uk-margin-small-bottom" type="number" label="Number" placeholder="Enter a number"/>
+            <oc-form-input class="uk-margin-small-bottom" type="email" label="Email" placeholder="Enter an email"/>
+            <oc-form-input class="uk-margin-small-bottom" type="password" label="Password" placeholder="Enter your password ;-)"/>
+            <h3 class="uk-heading-divider">
+                Binding
+            </h3>
+            <oc-form-input label="Text" placeholder="Write your text" v-model="inputValue"/>
+            <oc-form-input disabled label="Text" placeholder="Write your text" v-model="inputValue"/>
+            <h3 class="uk-heading-divider">
+                Interactions
+            </h3>
+            <oc-button @click="_focus">Focus input below</oc-button>
+            <oc-form-input label="Focus field" placeholder="Will you focus on me?" ref="inputForFocus"/>
+            <oc-button @click="_focusAndSelect">Focus and select input below</oc-button>
+            <oc-form-input label="Select field" value="Will you select this existing text?" ref="inputForFocusSelect"/>
+            <h3 class="uk-heading-divider">
+                Messages
+            </h3>
+            <oc-form-input
+                    label="Input with error and warning messages with reserved space below"
+                    class="uk-margin-small-bottom"
+                    placeholder="Text produces error on empty value and warning on trailing whitespace"
+                    v-model="valueForMessages"
+                    :error-message="errorMessage"
+                    :warning-message="warningMessage"
+                    :fix-message-line="true"
+            />
+            <oc-form-input
+                    label="Input with error and warning messages without reserved space below"
+                    class="uk-margin-small-bottom"
+                    placeholder="Text produces error on empty value and warning on trailing whitespace"
+                    v-model="valueForMessages"
+                    :error-message="errorMessage"
+                    :warning-message="warningMessage"
+            />
+        </section>
+    </template>
+    <script>
+      export default {
+        data: () => {
+          return {
+            inputValue: 'initial',
+            valueForMessages: '',
+          }
+        },
+        computed: {
+          errorMessage() {
+            return this.valueForMessages.length === 0 ? 'Value is required.' : ''
+          },
+          warningMessage() {
+            return this.valueForMessages.endsWith(' ') ? 'Trailing whitespace should be avoided.' : ''
+          }
+        },
+        methods: {
+          _focus() {
+            this.$refs.inputForFocus.$children[0].focus()
+          },
+          _focusAndSelect() {
+            this.$refs.inputForFocusSelect.$children[0].focus()
+          }
+        }
+      }
+    </script>
+    ```
+</docs>

--- a/src/patterns/OcSearchBar.vue
+++ b/src/patterns/OcSearchBar.vue
@@ -217,14 +217,14 @@ export default {
         Search example with visually hidden button
       </h3>
       <div class="uk-margin">
-        <oc-search-bar label="Search files" placeholder="Search files" @search="onSearch" @clear="onClear" button-hidden="true" />
+        <oc-search-bar label="Search files" placeholder="Search files" @search="onSearch" @clear="onClear" :button-hidden="true" />
       </div>
     </section>
     <section>
       <h3 class="uk-heading-divider">
           Filter examples
       </h3>
-      <oc-search-bar isFilter="true" label="Search files" placeholder="Filter Files ..." :type-ahead="true" @search="onFilter" button="Filter" icon=""></oc-search-bar>
+      <oc-search-bar :isFilter="true" label="Search files" placeholder="Filter Files ..." :type-ahead="true" @search="onFilter" button="Filter" icon=""></oc-search-bar>
       <div v-if="filterQuery" class="uk-margin">Filter query: {{ filterQuery }}</div>
     </section>
   </div>

--- a/src/styles/_owncloud.scss
+++ b/src/styles/_owncloud.scss
@@ -45,7 +45,8 @@
 @import "theme/oc-page-title";
 @import "theme/oc-dropdown";
 @import "theme/oc-tabbed";
-@import "theme/oc-spinner.scss";
+@import "theme/oc-spinner";
+@import "theme/oc-form-input";
 
 // 4. Import UIkit.
 @import "../../node_modules/uikit/src/scss/uikit-theme.scss";

--- a/src/styles/theme/oc-form-input.scss
+++ b/src/styles/theme/oc-form-input.scss
@@ -1,0 +1,18 @@
+//
+// Component: OC Form Input
+//
+// ========================================================================
+
+.oc-form-input-message {
+  @extend .uk-flex;
+  @extend .uk-flex-middle;
+  @extend .uk-margin-xsmall-top;
+  min-height: $global-font-size * 1.5;
+
+  .oc-form-input-warning {
+    color: $warning-background !important;
+  }
+  .oc-form-input-danger {
+    color: $danger-background !important;
+  }
+}

--- a/src/styles/theme/oc-text-input.scss
+++ b/src/styles/theme/oc-text-input.scss
@@ -24,9 +24,3 @@
   color: $danger-background !important;
   border-color: $danger-background !important;
 }
-.oc-text-input-message {
-  @extend .uk-flex;
-  @extend .uk-flex-middle;
-  @extend .uk-margin-xsmall-top;
-  min-height: $global-font-size * 1.5;
-}


### PR DESCRIPTION
Revert `oc-text-input` back to having the input as root element, but with the small addition of defining input border colors (validation) through properties.

Extracted the validation message line and properties into a new `oc-form-input` pattern component, which then reuses `oc-text-input` as the input element.