### PR TITLE
Fix OcAutocomplete

### DIFF
--- a/changelog/unreleased/710
+++ b/changelog/unreleased/710
@@ -1,0 +1,5 @@
+Bugfix: Fix oc-autocomplete
+
+We fixed a bug in OcAutocomplete which was introduced with the removal of lodash as a dependency.
+
+https://github.com/owncloud/owncloud-design-system/pull/710

--- a/src/patterns/OcAutocomplete.vue
+++ b/src/patterns/OcAutocomplete.vue
@@ -76,7 +76,7 @@
 import OcSpinner from "../elements/OcSpinner"
 
 import UiKit from "uikit"
-import { uniqueId as _uniqueId } from "../utils/uniqueId"
+import * as _uniqueId from "../utils/uniqueId"
 
 /**
  * The autocomplete component is used for searching in bigger list of data (usually involves remote calls over the network)


### PR DESCRIPTION
OcAutocomplete was broken because an aliased import was not working properly.