### PR TITLE
Do not emit value if input is disabled in modal

### DIFF
--- a/changelog/unreleased/modal-confirm-without-input-ref
+++ b/changelog/unreleased/modal-confirm-without-input-ref
@@ -1,0 +1,6 @@
+Bugfix: Do not try to emit value after confirming modal if input is missing
+
+Confirming modal resulted in an error if the modal haven't got an input.
+We've fixed this by not attempting to emit the value if the prop `hasInput` is set to false.
+
+https://github.com/owncloud/owncloud-design-system/pull/749

--- a/src/elements/OcModal.vue
+++ b/src/elements/OcModal.vue
@@ -213,12 +213,14 @@ export default {
     },
 
     $_ocModal_confirm() {
+      const value = this.hasInput ? this.$refs.ocModalInput.value : null
+
       /**
        * The user clicked on the confirm button. If input exists, emits it's value
        * 
        * @property {String} inputValue Value of the input
        */
-      this.$emit("confirm", this.$refs.ocModalInput.value)
+      this.$emit("confirm", value)
     },
 
     $_ocModal_input_type() {


### PR DESCRIPTION
Otherwise, the confirm would throw an error because of trying to reach non-existing ref.