### PR TITLE
Fix typo in color name

### DIFF
--- a/src/styles/theme/oc-modal.scss
+++ b/src/styles/theme/oc-modal.scss
@@ -35,7 +35,7 @@
     display: flex;
     flex-flow: row wrap;
     padding: $small-gutter $gutter;
-    background-color: $invers-color;
+    background-color: $inverse-color;
     font-weight: bold;
     align-items: center;
 
@@ -70,7 +70,7 @@
         border-radius: 4px;
 
         &.uk-button-default {
-          background-color: $invers-color;
+          background-color: $inverse-color;
           color: $color;
         }
       }

--- a/src/tokens/color.yml
+++ b/src/tokens/color.yml
@@ -23,7 +23,7 @@ props:
   link-hover-color:
     value: "#0066ff"
     category: "Font-colors"
-  invers-color:
+  inverse-color:
     value: "#fff"
     category: "Font-colors"
 


### PR DESCRIPTION
just a typo fix in a variable name. double checked in phoenix, that it's not directly used.