### PR TITLE
Add mainContent slot into sidebar

### DIFF
--- a/changelog/unreleased/sidebar-main-content
+++ b/changelog/unreleased/sidebar-main-content
@@ -1,0 +1,6 @@
+Enhancement: Add mainContent slot to the sidebar
+
+We've added slot called mainContent into the sidebar component.
+This slot replaces the navigation if defined.
+
+https://github.com/owncloud/owncloud-design-system/pull/804

--- a/src/elements/OcSidebar.spec.js
+++ b/src/elements/OcSidebar.spec.js
@@ -80,4 +80,19 @@ describe("OcSidebar", () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.emitted().close).toBeTruthy()
   })
+
+  it('Replaces navigation with a main content', () => {
+    const productDesc = 'Securely access and share data from everywhere and any device'
+    const wrapper = shallowMount(Sidebar, {
+      propsData: defaultProps,
+      slots: {
+        mainContent: productDesc
+      }
+    })
+
+    expect(wrapper.findAll('.oc-sidebar-main-content').length).toBe(1)
+    expect(wrapper.find('.oc-sidebar-main-content').text()).toMatch(productDesc)
+    expect(wrapper.findAll('.oc-sidebar-nav').length).toBe(0)
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/elements/OcSidebar.vue
+++ b/src/elements/OcSidebar.vue
@@ -24,7 +24,7 @@
         <!-- @slot Content above the navigation block -->
         <slot name="upperContent" />
       </div>
-      <nav :class="[{ 'uk-margin-bottom' : $slots.footer },  'oc-sidebar-nav']">
+      <nav v-if="navItems.length > 1 && !$slots.mainContent" key="sidebar-navigation" :class="[{ 'uk-margin-bottom' : $slots.footer },  'oc-sidebar-nav']">
         <ul>
           <oc-sidebar-nav-item
             v-for="item in navItems"
@@ -38,6 +38,9 @@
           </oc-sidebar-nav-item>
         </ul>
       </nav>
+      <div v-else key="sidebar-main-content" :class="[{ 'uk-margin-bottom' : $slots.footer },  'oc-sidebar-main-content']">
+        <slot name="mainContent" />
+      </div>
       <div v-if="$slots.footer" class="oc-sidebar-footer">
         <!-- @slot Footer of the sidebar -->
         <slot name="footer" />
@@ -84,7 +87,8 @@ export default {
      */
     navItems: {
       type: Array,
-      required: true
+      required: false,
+      default: () => []
     },
     /**
      * Asserts whether the sidebar's position is fixed
@@ -182,6 +186,23 @@ If a source of the logo image is not provided, the product name is used instead.
       }
     }
   </script>
+```
+
+The navigation inside of the sidebar can be replaced with a custom content via the slot called `mainContent`.
+In this content block, you can include e.g. a short description of the product, guide the user through the current action, etc.
+
+```js
+  <oc-sidebar
+    logoImg="https://owncloud.org/wp-content/themes/owncloud/img/owncloud-org-logo.svg"
+    productName="ownCloud"
+    class="uk-height-1-1"
+  >
+    <template v-slot:mainContent>
+      <div>
+        Securely access and share data from everywhere and any device
+      </div>
+    </template>
+  </oc-sidebar>
 ```
 
 To provide additional content above the navigation or in the footer, you can use the `upperContent` and `footer` slots.

--- a/src/elements/__snapshots__/OcSidebar.spec.js.snap
+++ b/src/elements/__snapshots__/OcSidebar.spec.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OcSidebar Replaces navigation with a main content 1`] = `
+<div class="oc-sidebar">
+  <div class="oc-sidebar-content-wrapper">
+    <!---->
+    <router-link-stub tag="a" to="/" class="oc-sidebar-logo"><span class="oc-sidebar-logo-text">ownCloud</span></router-link-stub>
+    <!---->
+    <div class="oc-sidebar-main-content">Securely access and share data from everywhere and any device</div>
+    <!---->
+  </div>
+</div>
+`;
+
 exports[`OcSidebar Sets fixed position 1`] = `
 <div class="oc-sidebar oc-sidebar-fixed">
   <div class="oc-sidebar-content-wrapper">

--- a/src/styles/theme/oc-sidebar.scss
+++ b/src/styles/theme/oc-sidebar.scss
@@ -89,6 +89,11 @@
     }
   }
 
+  &-main-content {
+    padding: 0 $small-gutter $gutter;
+    color: $global-inverse-color;
+  }
+
   &-footer {
     padding: 0 $small-gutter;
   }


### PR DESCRIPTION
The navigation inside of the sidebar can be replaced with a custom content via the slot called `mainContent`. In this slot can be included e.g. a short description of the product, guide the user through the current action, etc.