### PR TITLE
Add new variations and sizes of progress bar

### DIFF
--- a/changelog/unreleased/new-progress-bar
+++ b/changelog/unreleased/new-progress-bar
@@ -1,0 +1,7 @@
+Enhancement: Add new variations and sizes of progress bar
+
+We've added new variations and sizes of the progress bar component.
+Variations change the color of the progress bar and can be either `primary` or `warning`.
+Sizes affect the height of the progress bar where it can be either `default` or `small`.
+
+https://github.com/owncloud/owncloud-design-system/pull/819

--- a/src/elements/OcProgress.spec.js
+++ b/src/elements/OcProgress.spec.js
@@ -1,0 +1,19 @@
+import { shallowMount } from "@vue/test-utils"
+import Progress from "./OcProgress.vue"
+
+describe("OcProgress", () => {
+  it('sets correct classes', () => {
+    const wrapper = shallowMount(Progress, {
+      propsData: {
+        value: 3,
+        max: 10,
+        variation: 'warning',
+        size: 'small'
+      }
+    })
+
+    expect(wrapper.classes()).toContain('oc-progress-small')
+    expect(wrapper.classes()).toContain('oc-progress-warning')
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/src/elements/OcProgress.vue
+++ b/src/elements/OcProgress.vue
@@ -6,15 +6,12 @@
     :aria-valuenow="value"
     aria-busy="true"
     aria-valuemin="0"
-    class="uk-progress oc-progress"
+    :class="$_ocProgress_classes"
     tabindex="-1"
     role="progressbar"
-  ></progress>
+  />
 </template>
 <script>
-/**
- * Show progress to the users.
- */
 export default {
   name: "oc-progress",
   status: "review",
@@ -35,11 +32,40 @@ export default {
       type: Number,
       required: true,
     },
+    /**
+     * The size of the progress bar.
+     * Can be `default` or `small`
+     */
+    size: {
+      type: String,
+      required: false,
+      default: "default"
+    },
+    /**
+     * The variation of the progress bar.
+     * Can be `primary` or `warning`
+     */
+    variation: {
+      type: String,
+      required: false,
+      default: "primary"
+    }
   },
+
+  computed: {
+    $_ocProgress_classes() {
+      return `oc-progress oc-progress-${this.size} oc-progress-${this.variation}`
+    }
+  }
 }
 </script>
 <docs>
+Show progress to the users.
+
 ```jsx
-<oc-progress :value="4" :max="10" />
+<div>
+  <oc-progress :value="4" :max="10" class="uk-margin-small-bottom" />
+  <oc-progress :value="8" :max="10" size="small" variation="warning" />
+</div>
 ```
 </docs>

--- a/src/elements/OcProgress.vue
+++ b/src/elements/OcProgress.vue
@@ -39,7 +39,10 @@ export default {
     size: {
       type: String,
       required: false,
-      default: "default"
+      default: "default",
+      validator: value => {
+        return value.match(/(default|small)/)
+      }
     },
     /**
      * The variation of the progress bar.
@@ -48,7 +51,10 @@ export default {
     variation: {
       type: String,
       required: false,
-      default: "primary"
+      default: "primary",
+      validator: value => {
+        return value.match(/(primary|warning)/)
+      }
     }
   },
 

--- a/src/elements/__snapshots__/OcProgress.spec.js.snap
+++ b/src/elements/__snapshots__/OcProgress.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OcProgress sets correct classes 1`] = `<progress max="10" aria-valuemax="10" aria-valuenow="3" aria-busy="true" aria-valuemin="0" tabindex="-1" role="progressbar" class="oc-progress oc-progress-small oc-progress-warning" value="3"></progress>`;

--- a/src/styles/_owncloud.scss
+++ b/src/styles/_owncloud.scss
@@ -49,6 +49,7 @@
 @import "theme/oc-spinner.scss";
 @import "theme/oc-modal.scss";
 @import "theme/oc-sidebar.scss";
+@import "theme/oc-progress";
 
 // 4. Import UIkit.
 @import "../../node_modules/uikit/src/scss/uikit-theme.scss";

--- a/src/styles/_owncloud.scss
+++ b/src/styles/_owncloud.scss
@@ -49,7 +49,6 @@
 @import "theme/oc-spinner.scss";
 @import "theme/oc-modal.scss";
 @import "theme/oc-sidebar.scss";
-@import "theme/oc-progress";
 
 // 4. Import UIkit.
 @import "../../node_modules/uikit/src/scss/uikit-theme.scss";

--- a/src/styles/theme/_oc-progress.scss
+++ b/src/styles/theme/_oc-progress.scss
@@ -1,6 +1,0 @@
-.oc-progress {
-  &[tabindex="-1"]:focus {
-    // Remove focus when focus is set to element programmatically
-    outline: 0;
-  }
-}

--- a/src/styles/theme/oc-progress.scss
+++ b/src/styles/theme/oc-progress.scss
@@ -1,0 +1,75 @@
+// Variables
+// ========================================================================
+
+$progress-height: 15px !default;
+$progress-height-small: 5px !default;
+
+// Component
+// ========================================================================
+
+.oc-progress {
+    // Add the correct vertical alignment in Chrome, Firefox, and Opera.
+    vertical-align: baseline;
+    // Remove default style
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    display: block;
+    width: 100%;
+    // Remove default style
+    border: 0;
+    // Set background color for progress container in Firefox, IE11 and Edge
+    background-color: $global-inverse-color;
+    height: $progress-height;
+
+    &:focus {
+      outline: none;
+    }
+
+    // Remove animated circles for indeterminate state in IE11 and Edge
+    &:indeterminate {
+      color: transparent;
+    }
+
+    &::-webkit-progress-bar {
+      background-color: $global-inverse-color;
+    }
+
+    // Remove progress bar for indeterminate state in Firefox
+    &:indeterminate::-moz-progress-bar {
+      width: 0;
+    }
+
+    &::-webkit-progress-value {
+      background-color: $action-primary;
+      transition: width $transition-duration-short ease;
+    }
+
+    &::-moz-progress-bar {
+      background-color: $action-primary;
+    }
+
+    &::-ms-fill {
+      background-color: $action-primary;
+      transition: width $transition-duration-short ease;
+      // Remove right border in IE11 and Edge
+      border: 0;
+    }
+
+    &-small {
+      height: $progress-height-small;
+    }
+
+    &-warning {
+      &::-webkit-progress-value {
+        background-color: $warning-background;
+      }
+  
+      &::-moz-progress-bar {
+        background-color: $warning-background;
+      }
+  
+      &::-ms-fill {
+        background-color: $warning-background;
+      }
+    }
+}

--- a/src/styles/theme/oc-progress.scss
+++ b/src/styles/theme/oc-progress.scss
@@ -8,68 +8,68 @@ $progress-height-small: 5px !default;
 // ========================================================================
 
 .oc-progress {
-    // Add the correct vertical alignment in Chrome, Firefox, and Opera.
-    vertical-align: baseline;
-    // Remove default style
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    display: block;
-    width: 100%;
-    // Remove default style
-    border: 0;
-    // Set background color for progress container in Firefox, IE11 and Edge
+  // Add the correct vertical alignment in Chrome, Firefox, and Opera.
+  vertical-align: baseline;
+  // Remove default style
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  display: block;
+  width: 100%;
+  // Remove default style
+  border: 0;
+  // Set background color for progress container in Firefox, IE11 and Edge
+  background-color: $global-inverse-color;
+  height: $progress-height;
+
+  &:focus {
+    outline: none;
+  }
+
+  // Remove animated circles for indeterminate state in IE11 and Edge
+  &:indeterminate {
+    color: transparent;
+  }
+
+  &::-webkit-progress-bar {
     background-color: $global-inverse-color;
-    height: $progress-height;
+  }
 
-    &:focus {
-      outline: none;
-    }
+  &::-moz-progress-bar {
+    background-color: $action-primary;
+  }
 
-    // Remove animated circles for indeterminate state in IE11 and Edge
-    &:indeterminate {
-      color: transparent;
-    }
+  // Remove progress bar for indeterminate state in Firefox
+  &:indeterminate::-moz-progress-bar {
+    width: 0;
+  }
 
-    &::-webkit-progress-bar {
-      background-color: $global-inverse-color;
-    }
+  &::-webkit-progress-value {
+    background-color: $action-primary;
+    transition: width $transition-duration-short ease;
+  }
 
-    // Remove progress bar for indeterminate state in Firefox
-    &:indeterminate::-moz-progress-bar {
-      width: 0;
-    }
+  &::-ms-fill {
+    background-color: $action-primary;
+    transition: width $transition-duration-short ease;
+    // Remove right border in IE11 and Edge
+    border: 0;
+  }
 
+  &-small {
+    height: $progress-height-small;
+  }
+
+  &-warning {
     &::-webkit-progress-value {
-      background-color: $action-primary;
-      transition: width $transition-duration-short ease;
+      background-color: $warning-background;
     }
 
     &::-moz-progress-bar {
-      background-color: $action-primary;
+      background-color: $warning-background;
     }
 
     &::-ms-fill {
-      background-color: $action-primary;
-      transition: width $transition-duration-short ease;
-      // Remove right border in IE11 and Edge
-      border: 0;
+      background-color: $warning-background;
     }
-
-    &-small {
-      height: $progress-height-small;
-    }
-
-    &-warning {
-      &::-webkit-progress-value {
-        background-color: $warning-background;
-      }
-  
-      &::-moz-progress-bar {
-        background-color: $warning-background;
-      }
-  
-      &::-ms-fill {
-        background-color: $warning-background;
-      }
-    }
+  }
 }


### PR DESCRIPTION
We've added new variations and sizes of the progress bar component. Variations change the color of the progress bar and can be either `primary` or `warning`. Sizes affect the height of the progress bar where it can be either `default` or `small`.