### PR TITLE
Introduce property for hiding the navigation in the sidebar

### DIFF
--- a/src/elements/OcSidebar.spec.js
+++ b/src/elements/OcSidebar.spec.js
@@ -49,7 +49,7 @@ describe("OcSidebar", () => {
     expect(wrapper.find('.upper-slot').text()).toMatch('Files app')
     expect(wrapper.findAll('.footer-slot').length).toBe(1)
     expect(wrapper.find('.footer-slot').text()).toMatch('Made by ownClouders')
-    expect(wrapper.find('.oc-sidebar-nav').classes()).toContain('uk-margin-bottom')
+    expect(wrapper.find('.oc-sidebar-footer').classes()).toContain('uk-margin-top')
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -61,7 +61,7 @@ describe("OcSidebar", () => {
         closeButtonLabel: 'Close sidebar'
       }
     })
-  
+
     expect(wrapper.classes()).toContain('oc-sidebar-fixed')
     expect(wrapper.findAll('.oc-sidebar-button-close').length).toBe(1)
     expect(wrapper.find('.oc-sidebar-button-close').attributes('arialabel')).toMatch('Close sidebar')
@@ -81,7 +81,7 @@ describe("OcSidebar", () => {
     expect(wrapper.emitted().close).toBeTruthy()
   })
 
-  it('Replaces navigation with a main content', () => {
+  it('Has navigation and main content', () => {
     const productDesc = 'Securely access and share data from everywhere and any device'
     const wrapper = shallowMount(Sidebar, {
       propsData: defaultProps,
@@ -90,9 +90,11 @@ describe("OcSidebar", () => {
       }
     })
 
+    expect(wrapper.findAll('.oc-sidebar-nav').length).toBe(1)
+    expect(wrapper.findAll('.oc-sidebar-nav-item').length).toBe(3)
     expect(wrapper.findAll('.oc-sidebar-main-content').length).toBe(1)
     expect(wrapper.find('.oc-sidebar-main-content').text()).toMatch(productDesc)
-    expect(wrapper.findAll('.oc-sidebar-nav').length).toBe(0)
+    expect(wrapper.find('.oc-sidebar-main-content').classes()).toContain('uk-margin-top')
     expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/elements/OcSidebar.vue
+++ b/src/elements/OcSidebar.vue
@@ -38,7 +38,13 @@
           </oc-sidebar-nav-item>
         </ul>
       </nav>
-      <div v-if="$slots.mainContent" key="sidebar-main-content" class="oc-sidebar-main-content uk-margin-top">
+      <div
+        v-if="$slots.mainContent"
+        key="sidebar-main-content"
+        class="oc-sidebar-main-content"
+        :class="{ 'uk-margin-top': $slots.upperContent || $_ocSidebar_isNavigationVisible }"
+      >
+        <!-- @slot Content below the navigation block and above the footer -->
         <slot name="mainContent" />
       </div>
       <div v-if="$slots.footer" class="oc-sidebar-footer uk-margin-top">
@@ -64,7 +70,7 @@ export default {
     OcSidebarNavItem,
     OcImg,
     OcButton,
-    OcIcon
+    OcIcon,
   },
 
   props: {
@@ -73,14 +79,14 @@ export default {
      */
     logoImg: {
       type: String,
-      required: false
+      required: false,
     },
     /**
      * Name of the product where the sidebar is used
      */
     productName: {
       type: String,
-      required: true
+      required: true,
     },
     /**
      * Navigation items of the product
@@ -88,7 +94,7 @@ export default {
     navItems: {
       type: Array,
       required: false,
-      default: () => []
+      default: () => [],
     },
     /**
      * Hide navigation entirely
@@ -96,7 +102,7 @@ export default {
     hideNav: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
     /**
      * Asserts whether the sidebar's position is fixed
@@ -104,7 +110,7 @@ export default {
     fixed: {
       type: Boolean,
       required: false,
-      default: false
+      default: false,
     },
     /**
      * Accessibility label of the close button
@@ -112,8 +118,8 @@ export default {
     closeButtonLabel: {
       type: String,
       required: false,
-      default: "Close navigation menu"
-    }
+      default: "Close navigation menu",
+    },
   },
 
   computed: {
@@ -128,7 +134,7 @@ export default {
     },
     $_ocSidebar_isNavigationVisible() {
       return !this.hideNav && this.navItems.length > 0
-    }
+    },
   },
 
   methods: {
@@ -137,8 +143,8 @@ export default {
        * The user clicked on the close button
        */
       this.$emit("close")
-    }
-  }
+    },
+  },
 }
 </script>
 

--- a/src/elements/OcSidebar.vue
+++ b/src/elements/OcSidebar.vue
@@ -5,7 +5,7 @@
         v-if="fixed"
         class="oc-sidebar-button-close"
         variation="raw"
-        @click.native="$_ocSidebar_buttonClose_click" 
+        @click.native="$_ocSidebar_buttonClose_click"
         :aria-label="closeButtonLabel"
       >
         <oc-icon name="close" aria-hidden="true" />
@@ -24,7 +24,7 @@
         <!-- @slot Content above the navigation block -->
         <slot name="upperContent" />
       </div>
-      <nav v-if="navItems.length > 1 && !$slots.mainContent" key="sidebar-navigation" :class="[{ 'uk-margin-bottom' : $slots.footer },  'oc-sidebar-nav']">
+      <nav v-if="$_ocSidebar_isNavigationVisible" key="sidebar-navigation" :class="[{ 'uk-margin-bottom' : $slots.footer },  'oc-sidebar-nav']">
         <ul>
           <oc-sidebar-nav-item
             v-for="item in navItems"
@@ -91,6 +91,14 @@ export default {
       default: () => []
     },
     /**
+     * Hide navigation entirely
+     */
+    hideNav: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    /**
      * Asserts whether the sidebar's position is fixed
      */
     fixed: {
@@ -117,6 +125,9 @@ export default {
       }
 
       return classes
+    },
+    $_ocSidebar_isNavigationVisible() {
+      return !this.hideNav && this.navItems.length > 0
     }
   },
 
@@ -188,7 +199,7 @@ If a source of the logo image is not provided, the product name is used instead.
   </script>
 ```
 
-The navigation inside of the sidebar can be replaced with a custom content via the slot called `mainContent`.
+Custom content can be placed below the navigation inside of the sidebar via a slot called `mainContent`.
 In this content block, you can include e.g. a short description of the product, guide the user through the current action, etc.
 
 ```js
@@ -236,6 +247,39 @@ The navigation block will automatically receive bottom margin in case the `foote
             { name: 'Home', route: { path: '/' }, icon: 'home' },
             { name: 'All files', route: { path: '/files' }, icon: 'folder' },
             { name: 'Shared files', route: { path: '/shared' }, icon: 'share', active: true }
+          ]
+        }
+      }
+    }
+  </script>
+```
+
+The navigation block can be hidden entirely - for example in favor of the `mainContent` slot.
+
+```jsx
+  <template>
+    <div>
+      <oc-sidebar
+          logoImg="https://owncloud.org/wp-content/themes/owncloud/img/owncloud-org-logo.svg"
+          productName="ownCloud"
+          :navItems="navItems"
+          :hide-nav="true"
+          class="uk-height-1-1"
+      >
+        <template v-slot:mainContent>
+          <div>
+            There are navItems in the code but the navigation is hidden anyway.
+          </div>
+        </template>
+      </oc-sidebar>
+    </div>
+  </template>
+  <script>
+    export default {
+      computed: {
+        navItems() {
+          return [
+            { name: 'Home', route: { path: '/' }, icon: 'home' },
           ]
         }
       }

--- a/src/elements/OcSidebar.vue
+++ b/src/elements/OcSidebar.vue
@@ -24,7 +24,7 @@
         <!-- @slot Content above the navigation block -->
         <slot name="upperContent" />
       </div>
-      <nav v-if="$_ocSidebar_isNavigationVisible" key="sidebar-navigation" :class="[{ 'uk-margin-bottom' : $slots.footer },  'oc-sidebar-nav']">
+      <nav v-if="$_ocSidebar_isNavigationVisible" key="sidebar-navigation" class="oc-sidebar-nav">
         <ul>
           <oc-sidebar-nav-item
             v-for="item in navItems"
@@ -38,10 +38,10 @@
           </oc-sidebar-nav-item>
         </ul>
       </nav>
-      <div v-else key="sidebar-main-content" :class="[{ 'uk-margin-bottom' : $slots.footer },  'oc-sidebar-main-content']">
+      <div v-if="$slots.mainContent" key="sidebar-main-content" class="oc-sidebar-main-content uk-margin-top">
         <slot name="mainContent" />
       </div>
-      <div v-if="$slots.footer" class="oc-sidebar-footer">
+      <div v-if="$slots.footer" class="oc-sidebar-footer uk-margin-top">
         <!-- @slot Footer of the sidebar -->
         <slot name="footer" />
       </div>

--- a/src/elements/__snapshots__/OcSidebar.spec.js.snap
+++ b/src/elements/__snapshots__/OcSidebar.spec.js.snap
@@ -1,12 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcSidebar Replaces navigation with a main content 1`] = `
+exports[`OcSidebar Has navigation and main content 1`] = `
 <div class="oc-sidebar">
   <div class="oc-sidebar-content-wrapper">
     <!---->
     <router-link-stub tag="a" to="/" class="oc-sidebar-logo"><span class="oc-sidebar-logo-text">ownCloud</span></router-link-stub>
     <!---->
-    <div class="oc-sidebar-main-content">Securely access and share data from everywhere and any device</div>
+    <nav class="oc-sidebar-nav">
+      <ul>
+        <oc-sidebar-nav-item-stub target="/" icon="home" class="oc-sidebar-nav-item">
+          Home
+        </oc-sidebar-nav-item-stub>
+        <oc-sidebar-nav-item-stub target="/files" icon="folder" class="oc-sidebar-nav-item">
+          All files
+        </oc-sidebar-nav-item-stub>
+        <oc-sidebar-nav-item-stub active="true" target="/shared" icon="share" class="oc-sidebar-nav-item">
+          Shared files
+        </oc-sidebar-nav-item-stub>
+      </ul>
+    </nav>
+    <div class="oc-sidebar-main-content uk-margin-top">Securely access and share data from everywhere and any device</div>
     <!---->
   </div>
 </div>
@@ -34,6 +47,7 @@ exports[`OcSidebar Sets fixed position 1`] = `
       </ul>
     </nav>
     <!---->
+    <!---->
   </div>
 </div>
 `;
@@ -60,6 +74,7 @@ exports[`OcSidebar displays a logo image if its source is specified 1`] = `
       </ul>
     </nav>
     <!---->
+    <!---->
   </div>
 </div>
 `;
@@ -84,6 +99,7 @@ exports[`OcSidebar displays nav items 1`] = `
       </ul>
     </nav>
     <!---->
+    <!---->
   </div>
 </div>
 `;
@@ -94,7 +110,7 @@ exports[`OcSidebar displays upperContent and footer slots 1`] = `
     <!---->
     <router-link-stub tag="a" to="/" class="oc-sidebar-logo"><span class="oc-sidebar-logo-text">ownCloud</span></router-link-stub>
     <div class="oc-sidebar-upper-content"><strong class="upper-slot">Files app</strong></div>
-    <nav class="uk-margin-bottom oc-sidebar-nav">
+    <nav class="oc-sidebar-nav">
       <ul>
         <oc-sidebar-nav-item-stub target="/" icon="home" class="oc-sidebar-nav-item">
           Home
@@ -107,7 +123,8 @@ exports[`OcSidebar displays upperContent and footer slots 1`] = `
         </oc-sidebar-nav-item-stub>
       </ul>
     </nav>
-    <div class="oc-sidebar-footer"><small slot="footer" class="footer-slot">Made by ownClouders</small></div>
+    <!---->
+    <div class="oc-sidebar-footer uk-margin-top"><small slot="footer" class="footer-slot">Made by ownClouders</small></div>
   </div>
 </div>
 `;


### PR DESCRIPTION
We introduced a new property for the sidebar for hiding the navigation
entirely. The internal logic of not showing the navigation under certain
circumstances has been removed.

Please note that this is a breaking change. The navigation inside the sidebar might become visible in situations where it was not visible before.