### PR TITLE
Fix wrong extend syntax

### DIFF
--- a/changelog/unreleased/wrong-extend
+++ b/changelog/unreleased/wrong-extend
@@ -1,0 +1,6 @@
+Bugfix: Fix wrong extend syntax
+
+We've fixed the wrong extend syntax in oc-user-menu which was written in LESS.
+This syntax caused an issue with loading all styles and e.g. margin utility classes were not working.
+
+https://github.com/owncloud/owncloud-design-system/pull/870

--- a/src/styles/theme/oc-user-menu.scss
+++ b/src/styles/theme/oc-user-menu.scss
@@ -1,4 +1,7 @@
-.oc-user-menu:extend(.uk-navbar-dropdown, .uk-background-secondary) {
+.oc-user-menu {
+  @extend .uk-navbar-dropdown;
+  @extend .uk-background-secondary;
+
   &::before {
     content: '';
     height: 0;
@@ -11,7 +14,10 @@
     @extend .uk-navbar-dropdown-nav;
   }
 
-  li:extend(.uk-flex, .uk-flex-middle) {
+  li {
+    @extend .uk-flex;
+    @extend .uk-flex-middle;
+
     cursor: pointer;
     opacity: 0.75;
     transition: opacity 0.5s;


### PR DESCRIPTION
We've fixed the wrong extend syntax in oc-user-menu which was written in LESS.
This syntax caused an issue with loading all styles and e.g. margin utility classes were not working.