### PR TITLE
Use flexbox in buttons

### DIFF
--- a/changelog/unreleased/button-flex
+++ b/changelog/unreleased/button-flex
@@ -1,0 +1,6 @@
+Change: Use flexbox in buttons instead of css grid
+
+We've started using flexbox in the button component instead of css grid to position children correctly.
+This gives us more flexibility for the alignment of children.
+
+https://github.com/owncloud/owncloud-design-system/pull/873

--- a/src/styles/theme/oc-button.scss
+++ b/src/styles/theme/oc-button.scss
@@ -2,11 +2,10 @@
   align-items: center;
   border-color: transparent;
   border-radius: 3px;
-  column-gap: 10px;
-  display: grid;
+  display: flex;
   font-size: 1.125rem;
   font-weight: 600;
-  grid-auto-flow: column;
+  gap: 10px;
   line-height: 1.4;
   min-height: $global-control-height;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
We've started using flexbox in the button component instead of css grid to position children correctly.
This gives us more flexibility for the alignment of children.