### PR TITLE
Remove toggle fullscreen button

### DIFF
--- a/docs/components/Preview.js
+++ b/docs/components/Preview.js
@@ -43,25 +43,6 @@ export default previewComponent => {
         this.$el.localName +
         ">"
 
-      let button = document.createElement("button")
-      button.innerHTML = "Display component in fullscreen"
-      button.onclick = function() {
-        button.parentNode.requestFullscreen()
-        return false
-      }
-      document.addEventListener(
-        "fullscreenchange",
-        () => {
-          if (document.fullscreenElement) {
-            button.style.display = "none"
-          } else {
-            button.style.display = "block"
-          }
-        },
-        false
-      )
-      this.$el.prepend(button)
-
       const elemText = format(div, 0).innerHTML.replace(/ class=""/g, "")
       const elem = document.createElement("div")
       const pre = document.createElement("pre")


### PR DESCRIPTION
The "toggle fullscreen button" in docs was useful when we were still having "pages" section where was a content spanning the whole pages. Since they are removed I do not see a point in having this feature anymore. This cleans a bit the examples view.

![Screenshot 2020-12-02 at 10 15 06](https://user-images.githubusercontent.com/25989331/100852806-44892500-3487-11eb-863d-30555bade2b6.png)