### PR TITLE
Version bump for release 2.0.1

### DIFF
--- a/changelog/2.0.1_2020-12-02/fix-docs
+++ b/changelog/2.0.1_2020-12-02/fix-docs
@@ -1,0 +1,5 @@
+Bugfix: Fix component docs
+
+The docs were broken after merging Elements and Patterns into a Components section. Apparently `Components` is not allowed as section name for technical reasons, so we renamed it to `oC Components`.
+
+https://github.com/owncloud/owncloud-design-system/pull/937

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owncloud-design-system",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ownCloud Design System is based on VueDesign Systems and is used to design ownCloud UI components",
   "author": "ownClouders",
   "main": "dist/system/system.js",


### PR DESCRIPTION
Version bump for release 2.0.1 which fixes broken `component` docs.