### PR TITLE
Pin UIkit to v3.5.16

### DIFF
--- a/changelog/2.1.2_2020-01-21/pin-uikit
+++ b/changelog/2.1.2_2020-01-21/pin-uikit
@@ -1,0 +1,8 @@
+Change: Pin UIkit version to 3.5.16
+
+We've pinned the version of UIkit to 3.5.16.
+The reason for this is that the version 3.5.17 caused a regression to our autocomplete component.
+Since we want to remove UIkit from the ODS in the near future, we are not taking the time to come up with a fix.
+We do not plan to upgrade UIkit anymore.
+
+https://github.com/owncloud/owncloud-design-system/pull/1064

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owncloud-design-system",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "ownCloud Design System is based on VueDesign Systems and is used to design ownCloud UI components",
   "author": "ownClouders",
   "main": "dist/system/system.js",
@@ -44,7 +44,7 @@
     "postcss-safe-parser": "^5.0.2",
     "postcss-url": "^9.0.0",
     "tinycolor2": "^1.4.1",
-    "uikit": "3.6.13",
+    "uikit": "3.5.16",
     "vue": "^2.6.11",
     "vue-avatar": "^2.2.0",
     "vue-datetime": "^1.0.0-beta.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13133,10 +13133,10 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.12.1.tgz#78307f539f7b9ca5557babb186ea78ad30cc0375"
   integrity sha512-o8lHP20KjIiQe5b/67Rh68xEGRrc2SRsCuuoYclXXoC74AfSRGblU1HKzJWH3HxPZ+Ort85fWHpSX7KwBUC9CQ==
 
-uikit@3.6.13:
-  version "3.6.13"
-  resolved "https://registry.yarnpkg.com/uikit/-/uikit-3.6.13.tgz#2afca4cc7d4ab359907ae5cc64cb8d8b73085dab"
-  integrity sha512-XTLip7jfC5kYj2illklyXGHcMQh5x4mf69UU7xHQWgIrUBy+EVhD+KBfyff6KdIxI7M/tyaivAwLRRJcHH+Iow==
+uikit@3.5.16:
+  version "3.5.16"
+  resolved "https://registry.yarnpkg.com/uikit/-/uikit-3.5.16.tgz#c1803f03ab8891884b6a826838390e74c6636f47"
+  integrity sha512-v7LRuNDvrY2oU/qK16G/f6cSvMS8183saZ5p5f4jZjXGncTp1H2HsBV6v9+BC6yoaE2/etiCSp1z+Mrt4NJwPw==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
We've pinned the version of UIkit to 3.5.16.
The reason for this is that the version 3.5.17 caused a regression to our autocomplete component.
Since we want to remove UIkit from the ODS in the near future, we are not taking the time to come up with a fix.
We do not plan to upgrade UIkit anymore.