### PR TITLE
Remove basic styles

### DIFF
--- a/changelog/unreleased/remove-basic-styles
+++ b/changelog/unreleased/remove-basic-styles
@@ -1,0 +1,7 @@
+Change: Remove basic styles
+
+We've removed styles from the body element and from the #oc-content element.
+We were forcing styles on a global level which were too specific and because of that limited the usage of the design system.
+Any specific styling like that should be done in the consuming app.
+
+https://github.com/owncloud/owncloud-design-system/pull/1084

--- a/src/styles/_owncloud.scss
+++ b/src/styles/_owncloud.scss
@@ -19,7 +19,6 @@
 @import 'theme/menu-secondary';
 @import 'theme/animations';
 @import 'theme/oc-alert';
-@import 'theme/oc-app-container';
 @import 'theme/oc-app-menu';
 @import 'theme/oc-autocomplete';
 @import 'theme/oc-loader';

--- a/src/styles/theme/main.scss
+++ b/src/styles/theme/main.scss
@@ -1,12 +1,4 @@
-body {
-  height: 100vh;
-  overflow: hidden;
-}
-
 #oc-content {
-  height: 100vh;
-  overflow-x: hidden;
-  overflow-y: auto;
   scrollbar-width: thin;
 
   ::-webkit-scrollbar {

--- a/src/styles/theme/oc-app-container.scss
+++ b/src/styles/theme/oc-app-container.scss
@@ -1,4 +1,0 @@
-#oc-app-container {
-  height: calc(100vh - 60px);
-  overflow: hidden;
-}


### PR DESCRIPTION
We've removed styles from the body element and from the #oc-content element. We were forcing styles on a global level which were too specific and because of that limited the usage of the design system. Any specific styling like that should be done in the consuming app.