### PR TITLE
Merge resource target path with folder path

### DIFF
--- a/changelog/unreleased/remove-basic-styles copy
+++ b/changelog/unreleased/remove-basic-styles copy
@@ -1,0 +1,7 @@
+Change: Merge resource target path with folder path
+
+We've merged the resource target route path with the folder path in the `router-link`.
+When passing the path as a parameter, it wasn't being recognised and the navigation just pointed to the target route path.
+By explicitly merging them, we make sure that the navigation behaves as expected.
+
+https://github.com/owncloud/owncloud-design-system/pull/1085

--- a/src/components/resource/OcResource.vue
+++ b/src/components/resource/OcResource.vue
@@ -15,6 +15,7 @@
         v-bind="componentProps"
         v-if="isResourceClickable"
         @click.stop="emitClick"
+        @click.native.stop
       >
         <oc-resource-name :full-path="resource.path" :is-path-displayed="isPathDisplayed" />
       </component>
@@ -99,6 +100,12 @@ export default {
       return this.isResourceClickable && this.isFolder
     },
 
+    folderLink() {
+      const path = this.resource.path.replace(/^\//, "") // remove leading slash
+
+      return `${this.targetRoute}/${encodeURIComponent(path)}`
+    },
+
     componentProps() {
       if (!this.isRouterLink) {
         return {
@@ -108,7 +115,7 @@ export default {
       }
 
       return {
-        to: { path: this.targetRoute, params: { item: this.resource.path } },
+        to: this.folderLink,
       }
     },
   },

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -176,7 +176,7 @@ exports[`OcTableFiles displays all fields 1`] = `
     Object.assign({}, props, {'data-file-name': SvgFolder.name})
   );
 }</span>
-          <div class="oc-resource-details"><a to="[object Object]">
+          <div class="oc-resource-details"><a to="/Documents">
               <div class="oc-resource-name">
                 <!----> <span class="oc-resource-basename">Documents</span>
                 <!---->


### PR DESCRIPTION
We've merged the resource target route path with the folder path in the `router-link`. When passing the path as a parameter, it wasn't being recognised and the navigation just pointed to the target route path. By explicitly merging them, we make sure that the navigation behaves as expected.

Additional changes in this PR:
- Encode the path
- Stop propagation for the links to prevent opening sidebar in oC Web