### PR TITLE
Explicitly set oc-button:hover color & text-decoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ The following sections list the changes in ownCloud Design System unreleased.
 
 ## Summary
 
+* Bugfix - Button hover color fix: [#1091](https://github.com/owncloud/owncloud-design-system/pull/1091)
 * Change - Merge resource target path with folder path: [#1085](https://github.com/owncloud/owncloud-design-system/pull/1085)
 * Change - Remove basic styles: [#1084](https://github.com/owncloud/owncloud-design-system/pull/1084)
 * Enhancement - Remove the trailing slash from resource target path: [#1087](https://github.com/owncloud/owncloud-design-system/pull/1087)
 
 ## Details
+
+* Bugfix - Button hover color fix: [#1091](https://github.com/owncloud/owncloud-design-system/pull/1091)
+
+   When hovering the oc-button (*primary*) component had different styling, depending on if it was used as `a` or `button` tag.
+   This was caused by the underlying `ui-kit` styles, since no specific component-based styling was provided.
+   By making the hover styling explicit in the component stylesheet, this is fixed.
+   https://github.com/owncloud/owncloud-design-system/pull/1091
 
 * Change - Merge resource target path with folder path: [#1085](https://github.com/owncloud/owncloud-design-system/pull/1085)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,11 @@ The following sections list the changes in ownCloud Design System unreleased.
 
 ## Summary
 
-* Bugfix - Button hover color fix: [#1091](https://github.com/owncloud/owncloud-design-system/pull/1091)
 * Change - Merge resource target path with folder path: [#1085](https://github.com/owncloud/owncloud-design-system/pull/1085)
 * Change - Remove basic styles: [#1084](https://github.com/owncloud/owncloud-design-system/pull/1084)
 * Enhancement - Remove the trailing slash from resource target path: [#1087](https://github.com/owncloud/owncloud-design-system/pull/1087)
 
 ## Details
-
-* Bugfix - Button hover color fix: [#1091](https://github.com/owncloud/owncloud-design-system/pull/1091)
-
-   When hovering the oc-button (*primary*) component had different styling, depending on if it was used as `a` or `button` tag.
-   This was caused by the underlying `ui-kit` styles, since no specific component-based styling was provided.
-   By making the hover styling explicit in the component stylesheet, this is fixed.
-   https://github.com/owncloud/owncloud-design-system/pull/1091
 
 * Change - Merge resource target path with folder path: [#1085](https://github.com/owncloud/owncloud-design-system/pull/1085)
 

--- a/changelog/unreleased/fix-button-hover
+++ b/changelog/unreleased/fix-button-hover
@@ -1,0 +1,7 @@
+Bugfix: Button hover color
+
+When hovering the oc-button (*primary*) component had different styling, depending on if it was used as `a` or `button` tag.
+This was caused by the underlying `ui-kit` styles, since no specific component-based styling was provided.
+By making the hover styling explicit in the component stylesheet, this is fixed.
+
+https://github.com/owncloud/owncloud-design-system/pull/1091

--- a/src/styles/theme/oc-button.scss
+++ b/src/styles/theme/oc-button.scss
@@ -134,7 +134,9 @@
 
     &:hover,
     &:focus {
+      color: $global-inverse-color;
       background-color: $action-primary-hover;
+      text-decoration: none;
     }
   }
 

--- a/src/styles/theme/oc-button.scss
+++ b/src/styles/theme/oc-button.scss
@@ -134,8 +134,8 @@
 
     &:hover,
     &:focus {
-      color: $global-inverse-color;
       background-color: $action-primary-hover;
+      color: $global-inverse-color;
       text-decoration: none;
     }
   }


### PR DESCRIPTION
Fixes #899 (but there's more to it, see details below)

I tested the changes locally editing the code preview on the [OcButton](http://localhost:6060/#/oC%20Components/OcButton), as

```html
  <oc-button variation="primary" class="oc-mr-s" type="a">Primary button (a)</oc-button>
  <oc-button variation="primary" class="oc-mr-s" type="button">Primary button (button)</oc-button>
```

Having resolved the `color` problem I realized that `text-decoration` differs between `type="a"` and `type="button"`, so I decided to explicitly set it to `none` (as this is the case with other button types in use).


Just now I made the mistake and did some further investigation since oc-buttons can also be `"danger"` or `"inverse"` (default), and there's more odd behaviour with `color`, `text-decoration` but also `font-family`? 🤯 

To reproduce (and open further issues), feel free to use the snippet below:

```html
<oc-button variation="danger" type="button" class="oc-mr-s">
  <oc-icon name="delete" aria-hidden="true" />
  Danger Button
</oc-button>
<oc-button variation="danger" type="a" class="oc-mr-s">
  <oc-icon name="delete" aria-hidden="true" />
  Danger Button
</oc-button>
```