### PR TITLE
Add dynamic top position to table header

### DIFF
--- a/changelog/unreleased/dynamic-header-position
+++ b/changelog/unreleased/dynamic-header-position
@@ -1,0 +1,5 @@
+Enhancement: Add prop for the table header position
+
+We've added a prop which is defining the top position of the table header if the `sticky` prop is set to `true`.
+
+https://github.com/owncloud/owncloud-design-system/pull/1091

--- a/changelog/unreleased/dynamic-header-position
+++ b/changelog/unreleased/dynamic-header-position
@@ -2,4 +2,4 @@ Enhancement: Add prop for the table header position
 
 We've added a prop which is defining the top position of the table header if the `sticky` prop is set to `true`.
 
-https://github.com/owncloud/owncloud-design-system/pull/1091
+https://github.com/owncloud/owncloud-design-system/pull/1092

--- a/src/components/table/OcTable.vue
+++ b/src/components/table/OcTable.vue
@@ -7,6 +7,7 @@
           :key="`oc-thead-${field.name}`"
           v-bind="extractThProps(field)"
           :class="`oc-table-header-cell oc-table-header-cell-${field.name}`"
+          :style="{ top: sticky ? headerPosition + 'px' : null }"
         >
           <slot v-if="field.headerType === 'slot'" :name="field.name + 'Header'" />
           <template v-else>
@@ -136,6 +137,14 @@ export default {
       required: false,
       default: 64,
     },
+    /**
+     * Top position of header used when the header is sticky in pixels
+     */
+    headerPosition: {
+      type: Number,
+      required: false,
+      default: 0,
+    },
   },
   computed: {
     tableClasses() {
@@ -226,7 +235,6 @@ export default {
     .oc-table-header-cell {
       background-color: $inverse-color;
       position: sticky;
-      top: 0;
       z-index: 1;
     }
   }

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -5,6 +5,7 @@
     :highlighted="highlighted"
     :row-height="rowHeight"
     :sticky="true"
+    :header-position="headerPosition"
     @highlight="showDetails"
   >
     <template #selectHeader>
@@ -181,6 +182,14 @@ export default {
       type: Boolean,
       required: false,
       default: true,
+    },
+    /**
+     * Top position of header used when the header is sticky in pixels
+     */
+    headerPosition: {
+      type: Number,
+      required: false,
+      default: 0,
     },
   },
   computed: {

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -4,33 +4,33 @@ exports[`OcTableFiles displays all fields 1`] = `
 <table class="oc-table oc-table-sticky" slots="[object Object]">
   <thead class="oc-thead">
     <tr>
-      <th class="oc-th oc-table-cell oc-table-cell-align-left oc-table-cell-align-bottom oc-table-cell-width-shrink oc-table-header-cell oc-table-header-cell-select">
+      <th class="oc-th oc-table-cell oc-table-cell-align-left oc-table-cell-align-bottom oc-table-cell-width-shrink oc-table-header-cell oc-table-header-cell-select" style="top: 0px;">
         <div class="oc-table-files-select-all"><label for="oc-table-files-select-all" class="oc-cursor-pointer"><input id="oc-table-files-select-all" type="checkbox" name="checkbox" aria-label="Select all resources" class="oc-checkbox oc-checkbox-m" value="">
             <!---->
           </label></div>
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-left oc-table-cell-align-bottom oc-table-cell-width-expand oc-table-header-cell oc-table-header-cell-name">
+      <th class="oc-th oc-table-cell oc-table-cell-align-left oc-table-cell-align-bottom oc-table-cell-width-expand oc-table-header-cell oc-table-header-cell-name" style="top: 0px;">
         Name
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-size">
+      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-size" style="top: 0px;">
         Size
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-sharedWith">
+      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-sharedWith" style="top: 0px;">
         Shared with
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-owner">
+      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-owner" style="top: 0px;">
         Owner
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-mdate">
+      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-mdate" style="top: 0px;">
         Modified
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-sdate">
+      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-sdate" style="top: 0px;">
         Shared
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-ddate">
+      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-ddate" style="top: 0px;">
         Deleted
       </th>
-      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-actions">
+      <th class="oc-th oc-table-cell oc-table-cell-align-right oc-table-cell-align-bottom oc-table-cell-width-auto oc-table-header-cell oc-table-header-cell-actions" style="top: 0px;">
         Actions
       </th>
     </tr>


### PR DESCRIPTION
We've added a prop which is defining the top position of the table header if the `sticky` prop is set to `true`.