### PR TITLE
Use values as keys

### DIFF
--- a/changelog/unreleased/table-cells-keys
+++ b/changelog/unreleased/table-cells-keys
@@ -1,5 +1,5 @@
 Change: Use values as keys for table cells
 
-We've started using values as keys for the table celss so that they are reactive to the changes in values.
+We've started using values as keys for the table cells so that they are reactive to the changes in values.
 
 https://github.com/owncloud/owncloud-design-system/pull/1094

--- a/changelog/unreleased/table-cells-keys
+++ b/changelog/unreleased/table-cells-keys
@@ -1,0 +1,5 @@
+Change: Use values as keys for table cells
+
+We've started using values as keys for the table celss so that they are reactive to the changes in values.
+
+https://github.com/owncloud/owncloud-design-system/pull/1094

--- a/src/components/resource/OcResource.vue
+++ b/src/components/resource/OcResource.vue
@@ -17,7 +17,11 @@
         @click.stop="emitClick"
         @click.native.stop
       >
-        <oc-resource-name :full-path="resource.path" :is-path-displayed="isPathDisplayed" />
+        <oc-resource-name
+          :key="resource.name"
+          :full-path="resource.path"
+          :is-path-displayed="isPathDisplayed"
+        />
       </component>
       <oc-resource-name v-else :full-path="resource.path" :is-path-displayed="isPathDisplayed" />
       <div v-if="resource.indicators.length > 0" class="oc-resource-indicators">

--- a/src/components/table/OcTable.vue
+++ b/src/components/table/OcTable.vue
@@ -31,7 +31,7 @@
       >
         <oc-td
           v-for="field in fields"
-          :key="`oc-tbody-tr-${item[idKey] || index}-${field.name}`"
+          :key="cellKey(field, index, item)"
           :class="`oc-table-data-cell oc-table-data-cell-${field.name}`"
           v-bind="extractTdProps(field)"
         >
@@ -223,6 +223,20 @@ export default {
       }
 
       return this.disabled === item[this.idKey]
+    },
+
+    cellKey(field, index, item) {
+      const prefix = (item[this.idKey] || index) + "-"
+
+      if (this.isFieldTypeSlot(field)) {
+        return prefix + field.name
+      }
+
+      if (this.isFieldTypeCallback(field)) {
+        return prefix + field.callback(item[field.name])
+      }
+
+      return prefix + item[field.name]
     },
   },
 }

--- a/src/components/table/OcTable.vue
+++ b/src/components/table/OcTable.vue
@@ -31,7 +31,7 @@
       >
         <oc-td
           v-for="field in fields"
-          :key="cellKey(field, index, item)"
+          :key="'oc-tbody-tr-' + cellKey(field, index, item)"
           :class="`oc-table-data-cell oc-table-data-cell-${field.name}`"
           v-bind="extractTdProps(field)"
         >


### PR DESCRIPTION
We've started using values as keys for the table celss so that they are reactive to the changes in values.