### PR TITLE
Pass route object instead of string in targetRoute

### DIFF
--- a/changelog/unreleased/router-link-object
+++ b/changelog/unreleased/router-link-object
@@ -1,0 +1,7 @@
+CHANGE: Pass object as the target route
+
+We've changed the `targetRoute` prop in the `oc-resource` component to accept object instead of a string.
+This object is now accepting keys `name`, `params` and `query`. Only `name` is required.
+All keys are then passed to the router link which enables using more complex routes.
+
+https://github.com/owncloud/owncloud-design-system/pull/1102

--- a/changelog/unreleased/router-link-object
+++ b/changelog/unreleased/router-link-object
@@ -1,6 +1,6 @@
-CHANGE: Pass object as the target route
+Change: Pass object as the target route
 
-We've changed the `targetRoute` prop in the `oc-resource` component to accept object instead of a string.
+We've changed the `targetRoute` prop in the `oc-resource` component to accept an object instead of a string.
 This object is now accepting keys `name`, `params` and `query`. Only `name` is required.
 All keys are then passed to the router link which enables using more complex routes.
 

--- a/src/components/resource/OcResource.spec.js
+++ b/src/components/resource/OcResource.spec.js
@@ -21,6 +21,9 @@ describe("OcResource", () => {
     const wrapper = mount(Resource, {
       propsData: {
         resource: folderResource,
+        targetRoute: {
+          name: "tests-route"
+        }
       },
     })
 

--- a/src/components/resource/OcResource.vue
+++ b/src/components/resource/OcResource.vue
@@ -70,12 +70,37 @@ export default {
       default: true,
     },
     /**
-     * Target route path used to build the link when navigating into a resource
+     * Target route object used to build the link when navigating into a resource.
+     * @values { name, query }
      */
     targetRoute: {
-      type: String,
+      type: Object,
       required: false,
-      default: "",
+      default: null,
+      validator: value => {
+        if (!Object.prototype.hasOwnProperty.call(value, "name")) {
+          console.error("Target route needs to have a route name")
+
+          return false
+        }
+
+        if (typeof value.name !== "string") {
+          console.error("Target route name needs to be of type String")
+
+          return false
+        }
+
+        if (
+          Object.prototype.hasOwnProperty.call(value, "query") &&
+          typeof value.query !== "object"
+        ) {
+          console.error("Target route query needs to be of type Object")
+
+          return false
+        }
+
+        return true
+      },
     },
     /**
      * Asserts whether clicking on the resource name triggers any action
@@ -106,9 +131,15 @@ export default {
 
     folderLink() {
       const path = this.resource.path.replace(/^\//, "")
-      const targetPath = this.targetRoute.replace(/\/$/, "")
 
-      return `${targetPath}/${encodeURIComponent(path)}`
+      return {
+        name: this.targetRoute.name,
+        query: this.targetRoute.query,
+        params: {
+          item: path,
+          ...this.targetRoute.params,
+        },
+      }
     },
 
     componentProps() {
@@ -172,7 +203,7 @@ export default {
   ```vue
     <template>
       <div>
-        <oc-resource :resource="documents" targetRoute="/home" class="oc-mb" />
+        <oc-resource :resource="documents" :targetRoute="targetRoute" class="oc-mb" />
         <oc-resource :resource="notes" :isPathDisplayed="true" class="oc-mb" />
         <oc-resource :resource="notes" :isResourceClickable="false" class="oc-mb" />
         <oc-resource :resource="forest" :isPathDisplayed="true" />
@@ -224,6 +255,17 @@ export default {
               icon: 'link',
             }
           ]
+        },
+        targetRoute() {
+          return {
+            name: "home",
+            params: {
+              action: "copy"
+            },
+            query: {
+              resource: "notes"
+            }
+          }
         }
       },
     }

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -176,7 +176,7 @@ exports[`OcTableFiles displays all fields 1`] = `
     Object.assign({}, props, {'data-file-name': SvgFolder.name})
   );
 }</span>
-          <div class="oc-resource-details"><a to="/Documents">
+          <div class="oc-resource-details"><a to="[object Object]">
               <div class="oc-resource-name">
                 <!----> <span class="oc-resource-basename">Documents</span>
                 <!---->


### PR DESCRIPTION
We've changed the `targetRoute` prop in the `oc-resource` component to accept object instead of a string. This object is now accepting keys `name`, `params` and `query`. Only `name` is required. All keys are then passed to the router link which enables using more complex routes.