### PR TITLE
Remove overwritten ui-kit class from OcSidebar.vue

### DIFF
--- a/src/components/OcSidebar.vue
+++ b/src/components/OcSidebar.vue
@@ -160,7 +160,6 @@ Sidebar component containing branding and navigation
         logoImg="examples/placeholder_brand_logo.svg"
         productName="ownCloud"
         :navItems="navItems"
-        class="uk-height-1-1"
       />
     </div>
   </template>
@@ -187,7 +186,6 @@ If a source of the logo image is not provided, the product name is used instead.
       <oc-sidebar
         productName="ownCloud"
         :navItems="navItems"
-        class="uk-height-1-1"
       />
     </div>
   </template>
@@ -233,7 +231,6 @@ The navigation block will automatically receive bottom margin in case the `foote
         logoImg="examples/placeholder_brand_logo.svg"
         productName="ownCloud"
         :navItems="navItems"
-        class="uk-height-1-1"
       >
         <template v-slot:upperContent>
           <strong class="oc-light">Files app</strong>
@@ -267,11 +264,10 @@ The navigation block can be hidden entirely - for example in favor of the `mainC
   <template>
     <div>
       <oc-sidebar
-          logoImg="examples/placeholder_brand_logo.svg"
-          productName="ownCloud"
-          :navItems="navItems"
-          :hide-nav="true"
-          class="uk-height-1-1"
+        logoImg="examples/placeholder_brand_logo.svg"
+        productName="ownCloud"
+        :navItems="navItems"
+        :hide-nav="true"
       >
         <template v-slot:mainContent>
           <div>


### PR DESCRIPTION
The *class="uk-height-1-1"* in OcSidebar.vue translates to `height: 100;` and is outruled by `.oc-sidebar`'s `height: 100vh;`. It is also only used in the design system repo, not in web.

@LukasHirt do we need a CHANGELOG item for such minor fixes/documentation corrections, too?