### PR TITLE
Implement labels and descriptions for text input fields

### DIFF
--- a/changelog/unreleased/enhancement-textinput-labels-and-description
+++ b/changelog/unreleased/enhancement-textinput-labels-and-description
@@ -1,0 +1,5 @@
+Enhancement: Implement labels and descriptions for text input fields
+
+This also implies all the required accessibility changes.
+
+https://github.com/owncloud/owncloud-design-system/pull/1141

--- a/src/components/OcAccordion.vue
+++ b/src/components/OcAccordion.vue
@@ -204,7 +204,6 @@ To see documentation on how to use this component, see [oc-accordion-item](/#/oC
     </p>
   </oc-accordion-item>
   <oc-accordion-item title="Something else with content" description="And a subtitle" icon="file">
-      <p>Enter some text!</p>
       <oc-text-input label="Text"></oc-text-input>
   </oc-accordion-item>
 </oc-accordion>

--- a/src/components/OcTextInput.vue
+++ b/src/components/OcTextInput.vue
@@ -1,11 +1,10 @@
 <template>
   <div>
-    <label :id="labelId" class="oc-label" :for="inputId" v-text="label" />
+    <label class="oc-label" :for="inputId" v-text="label" />
     <input
       :id="inputId"
       v-bind="additionalAttributes"
       ref="input"
-      :aria-labelledby="labelId"
       :aria-invalid="ariaInvalid"
       :class="{
         'oc-text-input': !stopClassPropagation,
@@ -151,9 +150,6 @@ export default {
         return this.id
       }
       return uniqueId("oc-textinput-")
-    },
-    labelId() {
-      return `${this.inputId}-label`
     },
     messageId() {
       return `${this.inputId}-message`

--- a/src/components/OcTextInput.vue
+++ b/src/components/OcTextInput.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
-    <label class="oc-label" :for="inputId" v-text="label" />
+    <label class="oc-label" :for="id" v-text="label" />
     <input
-      :id="inputId"
+      :id="id"
       v-bind="additionalAttributes"
       ref="input"
       :aria-invalid="ariaInvalid"
@@ -40,8 +40,7 @@ import uniqueId from "../utils/uniqueId"
  * formats including numbers. For longer input, use the form `Textarea` element.*
  *
  * ## Accessibility
- * The label is required and represents the name of the input. The label element will automatically be referenced via
- * the `aria-labelledby` property.
+ * The label is required and represents the name of the input.
  *
  * The description-message can be used additionally to give further information about the input field. When a
  * description is given, it will be automatically referenced via the `aria-describedby` property.
@@ -60,7 +59,7 @@ export default {
     id: {
       type: String,
       required: false,
-      default: null,
+      default: () => uniqueId("oc-textinput-"),
     },
     /**
      * The type of the form input field.
@@ -145,14 +144,8 @@ export default {
 
       return listeners
     },
-    inputId() {
-      if (this.id) {
-        return this.id
-      }
-      return uniqueId("oc-textinput-")
-    },
     messageId() {
-      return `${this.inputId}-message`
+      return `${this.id}-message`
     },
     additionalAttributes() {
       const additionalAttrs = {}

--- a/src/components/OcTextInput.vue
+++ b/src/components/OcTextInput.vue
@@ -1,15 +1,17 @@
 <template>
   <div>
+    <label :id="$_ocTextInputLabel_Id" class="oc-label" :for="$_ocTextInput_Id" v-text="label" />
     <input
-      v-bind="$attrs"
+      :id="$_ocTextInput_Id"
+      v-bind="$_$attrs"
       ref="input"
-      :aria-label="label"
+      :aria-labelledby="$_ocTextInputLabel_Id"
+      :aria-invalid="$_ariaInvalid"
       :class="{
         'oc-text-input': !stopClassPropagation,
         'oc-text-input-warning': !!warningMessage,
         'oc-text-input-danger': !!errorMessage,
       }"
-      :placeholder="placeholder"
       :type="type"
       :value="value"
       v-on="$_ocTextInput_listeners"
@@ -17,20 +19,35 @@
       @focus="$_ocTextInput_onFocus($event.target)"
     />
     <div v-if="$_ocTextInput_showMessageLine" class="oc-text-input-message">
-      <span v-if="!!warningMessage" class="oc-text-input-warning" v-text="warningMessage" />
-      <span v-if="!!errorMessage" class="oc-text-input-danger" v-text="errorMessage" />
+      <span
+        :id="$_ocTextInputMessage_Id"
+        :class="{
+          'oc-text-input-description': !!descriptionMessage,
+          'oc-text-input-warning': !!warningMessage,
+          'oc-text-input-danger': !!errorMessage,
+        }"
+        v-text="$_message"
+      ></span>
     </div>
   </div>
 </template>
 
 <script>
+import uniqueId from "../utils/uniqueId"
+
 /**
  * Form Inputs are used to allow users to provide text input when the expected
  * input is short. Form Input has a range of options and supports several text
  * formats including numbers. For longer input, use the form `Textarea` element.*
  *
  * ## Accessibility
- * The attributes `placeholder` and `aria-label` have different functions. The first specifies a short hint describing the expected value of an input field/text area, or gives an example (e.g. email@example.com). `aria-label` provides the accessible name of the text input (e.g. "Your address", "Comment",...).
+ * The label is required and represents the name of the input. The label element will automatically be referenced via
+ * the `aria-labelledby` property.
+ *
+ * The description-message can be used additionally to give further information about the input field. When a
+ * description is given, it will be automatically referenced via the `aria-describedby` property.
+ * An error or warning will replace the description as well as the `aria-describedby` property until the error
+ * or warning is fixed.
  */
 export default {
   name: "OcTextInput",
@@ -38,6 +55,14 @@ export default {
   release: "1.0.0",
   inheritAttrs: false,
   props: {
+    /**
+     * The ID of the element.
+     */
+    id: {
+      type: String,
+      required: false,
+      default: null,
+    },
     /**
      * The type of the form input field.
      * `text, number, email, password`
@@ -64,13 +89,6 @@ export default {
     label: {
       type: String,
       required: true,
-      default: null,
-    },
-    /**
-     * The placeholder value for the form input field.
-     */
-    placeholder: {
-      type: String,
       default: null,
     },
     /**
@@ -102,10 +120,22 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * A description text which is shown below the input field.
+     */
+    descriptionMessage: {
+      type: String,
+      default: null,
+    },
   },
   computed: {
     $_ocTextInput_showMessageLine() {
-      return this.fixMessageLine || !!this.warningMessage || !!this.errorMessage
+      return (
+        this.fixMessageLine ||
+        !!this.warningMessage ||
+        !!this.errorMessage ||
+        !!this.descriptionMessage
+      )
     },
     $_ocTextInput_listeners() {
       const listeners = this.$listeners
@@ -115,6 +145,39 @@ export default {
       delete listeners["focus"]
 
       return listeners
+    },
+    $_ocTextInput_Id() {
+      if (this.id) {
+        return this.id
+      }
+      return uniqueId("oc-textinput-")
+    },
+    $_ocTextInputLabel_Id() {
+      return `${this.$_ocTextInput_Id}-label`
+    },
+    $_ocTextInputMessage_Id() {
+      return `${this.$_ocTextInput_Id}-message`
+    },
+    $_$attrs() {
+      const additionalAttrs = {}
+      if (!!this.warningMessage || !!this.errorMessage || !!this.descriptionMessage) {
+        additionalAttrs["aria-describedby"] = this.$_ocTextInputMessage_Id
+      }
+      return { ...this.$attrs, ...additionalAttrs }
+    },
+    $_ariaInvalid() {
+      return (!!this.errorMessage).toString()
+    },
+    $_message() {
+      if (this.errorMessage) {
+        return this.errorMessage
+      }
+
+      if (this.warningMessage) {
+        return this.warningMessage
+      }
+
+      return this.descriptionMessage
     },
   },
   methods: {
@@ -151,30 +214,35 @@ export default {
             <h3 class="uk-heading-divider">
                 Input Types
             </h3>
-            <oc-text-input class="oc-mb-s" label="Text" placeholder="Write your text"/>
+            <oc-text-input class="oc-mb-s" label="Text"/>
             <oc-text-input class="oc-mb-s" disabled label="Disabled" value="I am disabled"/>
-            <oc-text-input class="oc-mb-s" type="number" label="Number" placeholder="Enter a number"/>
-            <oc-text-input class="oc-mb-s" type="email" label="Email" placeholder="Enter an email"/>
-            <oc-text-input class="oc-mb-s" type="password" label="Password" placeholder="Enter your password ;-)"/>
+            <oc-text-input class="oc-mb-s" type="number" label="Number"/>
+            <oc-text-input class="oc-mb-s" type="email" label="Email"/>
+            <oc-text-input class="oc-mb-s" type="password" label="Password"/>
             <h3 class="uk-heading-divider">
                 Binding
             </h3>
-            <oc-text-input label="Text" placeholder="Write your text" v-model="inputValue"/>
-            <oc-text-input disabled label="Text" placeholder="Write your text" v-model="inputValue"/>
+            <oc-text-input label="Text" v-model="inputValue"/>
+            <oc-text-input disabled label="Text" v-model="inputValue"/>
             <h3 class="uk-heading-divider">
                 Interactions
             </h3>
             <oc-button @click="_focus">Focus input below</oc-button>
-            <oc-text-input label="Focus field" placeholder="Will you focus on me?" ref="inputForFocus"/>
+            <oc-text-input label="Focus field" ref="inputForFocus"/>
             <oc-button @click="_focusAndSelect">Focus and select input below</oc-button>
             <oc-text-input label="Select field" value="Will you select this existing text?" ref="inputForFocusSelect"/>
             <h3 class="uk-heading-divider">
                 Messages
             </h3>
             <oc-text-input
+                    label="Input with description message below"
+                    class="oc-mb-s"
+                    description-message="This is a description message."
+                    :fix-message-line="true"
+            />
+            <oc-text-input
                     label="Input with error and warning messages with reserved space below"
                     class="oc-mb-s"
-                    placeholder="Text produces error on empty value and warning on trailing whitespace"
                     v-model="valueForMessages"
                     :error-message="errorMessage"
                     :warning-message="warningMessage"
@@ -183,7 +251,6 @@ export default {
             <oc-text-input
                     label="Input with error and warning messages without reserved space below"
                     class="oc-mb-s"
-                    placeholder="Text produces error on empty value and warning on trailing whitespace"
                     v-model="valueForMessages"
                     :error-message="errorMessage"
                     :warning-message="warningMessage"

--- a/src/components/OcTextInput.vue
+++ b/src/components/OcTextInput.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
-    <label :id="$_ocTextInputLabel_Id" class="oc-label" :for="$_ocTextInput_Id" v-text="label" />
+    <label :id="labelId" class="oc-label" :for="inputId" v-text="label" />
     <input
-      :id="$_ocTextInput_Id"
-      v-bind="$_$attrs"
+      :id="inputId"
+      v-bind="additionalAttributes"
       ref="input"
-      :aria-labelledby="$_ocTextInputLabel_Id"
-      :aria-invalid="$_ariaInvalid"
+      :aria-labelledby="labelId"
+      :aria-invalid="ariaInvalid"
       :class="{
         'oc-text-input': !stopClassPropagation,
         'oc-text-input-warning': !!warningMessage,
@@ -14,19 +14,19 @@
       }"
       :type="type"
       :value="value"
-      v-on="$_ocTextInput_listeners"
-      @input="$_ocTextInput_onInput($event.target.value)"
-      @focus="$_ocTextInput_onFocus($event.target)"
+      v-on="listeners"
+      @input="onInput($event.target.value)"
+      @focus="onFocus($event.target)"
     />
-    <div v-if="$_ocTextInput_showMessageLine" class="oc-text-input-message">
+    <div v-if="showMessageLine" class="oc-text-input-message">
       <span
-        :id="$_ocTextInputMessage_Id"
+        :id="messageId"
         :class="{
           'oc-text-input-description': !!descriptionMessage,
           'oc-text-input-warning': !!warningMessage,
           'oc-text-input-danger': !!errorMessage,
         }"
-        v-text="$_message"
+        v-text="messageText"
       ></span>
     </div>
   </div>
@@ -129,7 +129,7 @@ export default {
     },
   },
   computed: {
-    $_ocTextInput_showMessageLine() {
+    showMessageLine() {
       return (
         this.fixMessageLine ||
         !!this.warningMessage ||
@@ -137,7 +137,7 @@ export default {
         !!this.descriptionMessage
       )
     },
-    $_ocTextInput_listeners() {
+    listeners() {
       const listeners = this.$listeners
 
       // Delete listeners for events which are emitted via methods
@@ -146,29 +146,29 @@ export default {
 
       return listeners
     },
-    $_ocTextInput_Id() {
+    inputId() {
       if (this.id) {
         return this.id
       }
       return uniqueId("oc-textinput-")
     },
-    $_ocTextInputLabel_Id() {
-      return `${this.$_ocTextInput_Id}-label`
+    labelId() {
+      return `${this.inputId}-label`
     },
-    $_ocTextInputMessage_Id() {
-      return `${this.$_ocTextInput_Id}-message`
+    messageId() {
+      return `${this.inputId}-message`
     },
-    $_$attrs() {
+    additionalAttributes() {
       const additionalAttrs = {}
       if (!!this.warningMessage || !!this.errorMessage || !!this.descriptionMessage) {
-        additionalAttrs["aria-describedby"] = this.$_ocTextInputMessage_Id
+        additionalAttrs["aria-describedby"] = this.messageId
       }
       return { ...this.$attrs, ...additionalAttrs }
     },
-    $_ariaInvalid() {
+    ariaInvalid() {
       return (!!this.errorMessage).toString()
     },
-    $_message() {
+    messageText() {
       if (this.errorMessage) {
         return this.errorMessage
       }
@@ -188,14 +188,14 @@ export default {
     focus() {
       this.$refs.input.focus()
     },
-    $_ocTextInput_onInput(value) {
+    onInput(value) {
       /**
        * Input event
        * @type {event}
        **/
       this.$emit("input", value)
     },
-    $_ocTextInput_onFocus(target) {
+    onFocus(target) {
       target.select()
       /**
        * Focus event - emitted as soon as the input field is focused

--- a/src/components/__snapshots__/OcModal.spec.js.snap
+++ b/src/components/__snapshots__/OcModal.spec.js.snap
@@ -7,7 +7,7 @@ exports[`OcModal displays input 1`] = `
       <!----> <span>Create new folder</span>
     </div>
     <div class="oc-modal-body">
-      <oc-text-input-stub type="text" value="New folder" label="Folder name" fixmessageline="true" class="oc-modal-body-input"></oc-text-input-stub>
+      <oc-text-input-stub id="oc-textinput-1" type="text" value="New folder" label="Folder name" fixmessageline="true" class="oc-modal-body-input"></oc-text-input-stub>
       <div class="oc-modal-body-actions uk-flex uk-flex-right">
         <oc-button-stub type="button" size="medium" variation="default" justifycontent="center" gapsize="medium" color="default" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
         <oc-button-stub type="button" size="medium" variation="primary" justifycontent="center" gapsize="medium" color="default" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>

--- a/src/styles/theme/oc-text-input.scss
+++ b/src/styles/theme/oc-text-input.scss
@@ -27,6 +27,12 @@
     color: $danger-background;
   }
 
+  &-description,
+  &-description:focus {
+    border-color: $muted-color;
+    color: $muted-color;
+  }
+
   &-message {
     @extend .uk-flex;
     @extend .uk-flex-middle;


### PR DESCRIPTION
* Remove placeholders
* Add required label to text inputs
* Add optional description message to text inputs
* Add `aria-describedby` which either references the description (if given), or an error/warning (if given)
* Add `aria-invalid` property