### PR TITLE
Prevent having to double-click on toplevel nav items

### DIFF
--- a/docs/docs.styles.scss
+++ b/docs/docs.styles.scss
@@ -310,7 +310,7 @@ div[class^="rsg--sidebar"] {
   }
 
   // Sidebar active link
-  .vueds-active {
+  .vueds-active, li[class*="rsg--isSelected-"] {
     ul[class^="rsg--list"] {
       display: block;
     }


### PR DESCRIPTION
Ugly stuff happening here, the `vueds-active` class is attached and instantly replaced on the first visit of toplevel nav items...

This partly fixes #812 (doesn't feel like it deserves a changelog item, though).