### PR TITLE
Release 3.2.1

### DIFF
--- a/changelog/3.2.1_2021-03-17/bugfix-folder-names
+++ b/changelog/3.2.1_2021-03-17/bugfix-folder-names
@@ -1,0 +1,5 @@
+Bugfix: Folder names with dots
+
+Folder names with dots showed were separated into a basename and extension part in the oc-resource-name component, which has been fixed. Additionally, the oc-resource-name component now as a `resource-type` attribute, which reflects the `type` property of the displayed resource. This makes testing easier.
+
+https://github.com/owncloud/owncloud-design-system/pull/1153

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owncloud-design-system",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "ownCloud Design System is based on VueDesign Systems and is used to design ownCloud UI components",
   "author": "ownClouders",
   "main": "dist/system/system.js",

--- a/src/components/resource/OcResource.vue
+++ b/src/components/resource/OcResource.vue
@@ -260,7 +260,8 @@ export default {
         notes() {
           return {
             name: "notes.txt",
-            path: "/Documents/notes.txt",
+            extension: "txt",
+            path: "Documents/notes.txt",
             icon: "text",
             indicators: this.indicators,
             type: "file"
@@ -268,7 +269,8 @@ export default {
         },
         forest() {
           return {
-            name: "forest.jpg",
+            name: "forest-image-with-filename-with-a-lot-of-characters.jpg",
+            extension: "jpg",
             path: "images/nature/forest-image-with-filename-with-a-lot-of-characters.jpg",
             preview: "https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg",
             indicators: [],

--- a/src/components/resource/OcResource.vue
+++ b/src/components/resource/OcResource.vue
@@ -28,11 +28,21 @@
       >
         <oc-resource-name
           :key="resource.name"
+          :name="resource.name"
+          :extension="resource.extension"
+          :type="resource.type"
           :full-path="resource.path"
           :is-path-displayed="isPathDisplayed"
         />
       </component>
-      <oc-resource-name v-else :full-path="resource.path" :is-path-displayed="isPathDisplayed" />
+      <oc-resource-name
+        v-else
+        :name="resource.name"
+        :extension="resource.extension"
+        :type="resource.type"
+        :full-path="resource.path"
+        :is-path-displayed="isPathDisplayed"
+      />
       <div v-if="resource.indicators.length > 0" class="oc-resource-indicators">
         <oc-status-indicators :resource="resource" :indicators="resource.indicators" />
       </div>

--- a/src/components/resource/OcResourceName.spec.js
+++ b/src/components/resource/OcResourceName.spec.js
@@ -3,6 +3,9 @@ import { shallowMount } from "@vue/test-utils"
 import Name from "./OcResourceName.vue"
 
 const fullPath = "images/nature/forest.jpg"
+const name = "forest.jpg"
+const extension = "jpg"
+const type = "file"
 
 describe("OcResourceName", () => {
   it("displays full path", () => {
@@ -10,13 +13,16 @@ describe("OcResourceName", () => {
       propsData: {
         fullPath,
         isPathDisplayed: true,
+        name,
+        extension,
+        type,
       },
     })
 
     expect(wrapper.find(".oc-resource-path").text()).toMatch("…/nature/")
     expect(wrapper.find(".oc-resource-basename").text()).toMatch("forest")
     expect(wrapper.find(".oc-resource-extension").text()).toMatch(".jpg")
-    expect(wrapper.find(".oc-resource-name").attributes(["uk-tooltip"])).toMatch(
+    expect(wrapper.find(".oc-resource-name").attributes("uk-tooltip")).toMatch(
       "images/nature/forest.jpg"
     )
     expect(wrapper).toMatchSnapshot()
@@ -27,6 +33,9 @@ describe("OcResourceName", () => {
       propsData: {
         fullPath: "Documents/notes.txt",
         isPathDisplayed: true,
+        name: "notes.txt",
+        extension: "txt",
+        type: "file",
       },
     })
 
@@ -40,10 +49,13 @@ describe("OcResourceName", () => {
     const wrapper = shallowMount(Name, {
       propsData: {
         fullPath,
+        name,
+        extension,
+        type,
       },
     })
 
-    expect(wrapper.findAll(".oc-resource-path").length).toBe(0)
+    expect(wrapper.find(".oc-resource-path").exists()).toBeFalsy()
     expect(wrapper.find(".oc-resource-basename").text()).toMatch("forest")
     expect(wrapper.find(".oc-resource-extension").text()).toMatch(".jpg")
     expect(wrapper).toMatchSnapshot()
@@ -53,11 +65,45 @@ describe("OcResourceName", () => {
     const wrapper = shallowMount(Name, {
       propsData: {
         fullPath: ".hidden",
+        name: ".hidden",
+        extension: "",
+        type: "folder",
       },
     })
 
     expect(wrapper.find(".oc-resource-basename").text()).toMatch(".hidden")
-    expect(wrapper.findAll(".oc-resource-extension").length).toBe(0)
+    expect(wrapper.find(".oc-resource-extension").exists()).toBeFalsy()
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it("renders folder names with dots completely in the basename", () => {
+    const wrapper = shallowMount(Name, {
+      propsData: {
+        fullPath: "folder.with.dots",
+        name: "folder.with.dots",
+        extension: "",
+        type: "folder",
+      },
+    })
+
+    expect(wrapper.find(".oc-resource-basename").text()).toMatch("folder.with.dots")
+    expect(wrapper.find(".oc-resource-extension").exists()).toBeFalsy()
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it("has properties for resource path, name and type", () => {
+    const wrapper = shallowMount(Name, {
+      propsData: {
+        fullPath,
+        name,
+        extension,
+        type,
+      },
+    })
+
+    const node = wrapper.find(".oc-resource-name")
+    expect(node.attributes("resource-type")).toMatch(type)
+    expect(node.attributes("resource-name")).toMatch(name)
+    expect(node.attributes("resource-path")).toMatch("/" + name)
   })
 })

--- a/src/components/resource/OcResourceName.vue
+++ b/src/components/resource/OcResourceName.vue
@@ -4,11 +4,12 @@
     v-bind="tooltip"
     :resource-path="fullPath"
     :resource-name="fullName"
+    :resource-type="type"
   >
-    <span v-if="hasPath" class="oc-resource-path" v-text="path" /><span
+    <span v-if="displayPath" class="oc-resource-path" v-text="displayPath" /><span
       class="oc-resource-basename"
-      v-text="name"
-    /><span v-if="extension" class="oc-resource-extension" v-text="extension" />
+      v-text="displayName"
+    /><span v-if="extension" class="oc-resource-extension" v-text="displayExtension" />
   </div>
 </template>
 
@@ -19,6 +20,28 @@ export default {
   released: "2.1.0",
 
   props: {
+    /**
+     * The name of the resource
+     */
+    name: {
+      type: String,
+      required: true,
+    },
+    /**
+     * The extension of the resource, if there is one
+     */
+    extension: {
+      type: String,
+      required: false,
+      default: "",
+    },
+    /**
+     * The type of the resource
+     */
+    type: {
+      type: String,
+      required: true,
+    },
     /**
      * A full path of the resource
      */
@@ -36,18 +59,7 @@ export default {
     },
   },
 
-  data: () => ({
-    name: "",
-    extension: "",
-    path: "",
-    pathTooltip: "",
-  }),
-
   computed: {
-    hasPath() {
-      return this.path !== ""
-    },
-
     tooltip() {
       if (this.pathTooltip) {
         return { "uk-tooltip": this.pathTooltip }
@@ -56,41 +68,42 @@ export default {
     },
 
     fullName() {
-      return this.path + this.name + this.extension
+      return (this.displayPath || "") + this.name
     },
-  },
 
-  watch: {
-    name: {
-      handler: "splitName",
-      immediate: true,
+    displayName() {
+      if (this.extension) {
+        return this.name.substr(0, this.name.length - this.extension.length - 1)
+      }
+      return this.name
     },
-  },
 
-  methods: {
-    splitName() {
-      const hasLeadingSlash = this.fullPath.startsWith("/")
-      const pathSplit = this.fullPath.substr(hasLeadingSlash ? 1 : 0).split("/")
+    displayExtension() {
+      return this.extension ? "." + this.extension : ""
+    },
 
-      if (this.isPathDisplayed) {
-        if (pathSplit.length === 2) {
-          this.path = pathSplit[0] + "/"
-        } else if (pathSplit.length > 2) {
-          this.path = `…/${pathSplit[pathSplit.length - 2]}/`
-          this.pathTooltip = this.fullPath
-        }
+    displayPath() {
+      if (!this.isPathDisplayed) {
+        return null
       }
-
-      const name = pathSplit[pathSplit.length - 1]
-      const dotIndex = name.lastIndexOf(".")
-
-      // If last index of "dot" is 0 or less, it is folder and we do not display extension
-      if (dotIndex <= 0) {
-        return (this.name = name)
+      const pathSplit = this.fullPath.replace(/^\//, "").split("/")
+      if (pathSplit.length < 2) {
+        return null
       }
+      if (pathSplit.length === 2) {
+        return pathSplit[0] + "/"
+      }
+      return `…/${pathSplit[pathSplit.length - 2]}/`
+    },
 
-      this.name = name.substring(0, dotIndex)
-      this.extension = name.substring(dotIndex)
+    pathTooltip() {
+      if (!this.isPathDisplayed) {
+        return null
+      }
+      if (this.displayPath === this.fullPath) {
+        return null
+      }
+      return this.fullPath
     },
   },
 }
@@ -118,8 +131,10 @@ export default {
 
 <docs>
 ```vue
-<oc-resource-name full-path="documents/notes.txt" />
-<oc-resource-name full-path="images/nature/forest.jpg" :is-path-displayed="true" />
-<oc-resource-name full-path="super-long-path-to-a-subfolder-which-is-a-lot-of-levels-away-from–the-root-super-long-path-to-a-subfolder-which-is-a-lot-of-levels-away-from–the-root/asdf.txt" :is-path-displayed="true" />
+<oc-resource-name full-path="documents/notes.txt" name="notes.txt" extension="txt" type="file" />
+<oc-resource-name full-path="images/nature/forest.jpg" :is-path-displayed="true" name="forest.jpg" extension="jpg" type="file" />
+<oc-resource-name full-path="super-long-path-to-a-subfolder-which-is-a-lot-of-levels-away-from–the-root-super-long-path-to-a-subfolder-which-is-a-lot-of-levels-away-from–the-root/asdf.txt" :is-path-displayed="true" name="asdf.txt" extension="txt" type="file" />
+<oc-resource-name full-path="some-folder" name="regular-folder" extension="" type="folder" />
+<oc-resource-name full-path="folder-name-with.dot" name="folder-name-with.dot" extension="" type="folder" />
 ```
 </docs>

--- a/src/components/resource/__snapshots__/OcResourceName.spec.js.snap
+++ b/src/components/resource/__snapshots__/OcResourceName.spec.js.snap
@@ -1,18 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcResourceName displays full path 1`] = `<div resource-path="images/nature/forest.jpg" resource-name="…/nature/forest.jpg" uk-tooltip="images/nature/forest.jpg" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">…/nature/</span><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span></div>`;
+exports[`OcResourceName displays full path 1`] = `<div resource-path="images/nature/forest.jpg" resource-name="…/nature/forest.jpg" resource-type="file" uk-tooltip="images/nature/forest.jpg" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">…/nature/</span><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span></div>`;
 
-exports[`OcResourceName displays only direct parent 1`] = `<div resource-path="Documents/notes.txt" resource-name="Documents/notes.txt" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">Documents/</span><span class="oc-resource-basename">notes</span><span class="oc-resource-extension">.txt</span></div>`;
+exports[`OcResourceName displays only direct parent 1`] = `<div resource-path="Documents/notes.txt" resource-name="Documents/notes.txt" resource-type="file" uk-tooltip="Documents/notes.txt" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">Documents/</span><span class="oc-resource-basename">notes</span><span class="oc-resource-extension">.txt</span></div>`;
 
 exports[`OcResourceName doesn't add extension to hidden folder 1`] = `
-<div resource-path=".hidden" resource-name=".hidden" class="oc-resource-name oc-text-truncate">
+<div resource-path=".hidden" resource-name=".hidden" resource-type="folder" class="oc-resource-name oc-text-truncate">
   <!----><span class="oc-resource-basename">.hidden</span>
   <!---->
 </div>
 `;
 
 exports[`OcResourceName hides the path if not enabled 1`] = `
-<div resource-path="images/nature/forest.jpg" resource-name="forest.jpg" class="oc-resource-name oc-text-truncate">
+<div resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate">
   <!----><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span>
+</div>
+`;
+
+exports[`OcResourceName renders folder names with dots completely in the basename 1`] = `
+<div resource-path="folder.with.dots" resource-name="folder.with.dots" resource-type="folder" class="oc-resource-name oc-text-truncate">
+  <!----><span class="oc-resource-basename">folder.with.dots</span>
+  <!---->
 </div>
 `;

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -43,8 +43,9 @@ exports[`OcTableFiles displays all fields 1`] = `
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><img src="https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg" aria-hidden="true" width="40" height="40" class="oc-resource-preview">
           <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-raw oc-button-raw-color-default">
-              <div resource-path="images/nature/forest.jpg" resource-name="forest.jpg" class="oc-resource-name oc-text-truncate">
-                <!----><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span>
+              <div resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate">
+                <!----><span class="oc-resource-basename">forest.jpg</span>
+                <!---->
               </div>
             </button>
             <div class="oc-resource-indicators">
@@ -112,8 +113,9 @@ exports[`OcTableFiles displays all fields 1`] = `
   );
 }</span>
           <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-raw oc-button-raw-color-default">
-              <div resource-path="/Documents/notes.txt" resource-name="notes.txt" class="oc-resource-name oc-text-truncate">
-                <!----><span class="oc-resource-basename">notes</span><span class="oc-resource-extension">.txt</span>
+              <div resource-path="/Documents/notes.txt" resource-name="notes.txt" resource-type="file" class="oc-resource-name oc-text-truncate">
+                <!----><span class="oc-resource-basename">notes.txt</span>
+                <!---->
               </div>
             </button>
             <div class="oc-resource-indicators">
@@ -181,7 +183,7 @@ exports[`OcTableFiles displays all fields 1`] = `
   );
 }</span>
           <div class="oc-resource-details oc-text-overflow"><a class="oc-text-overflow">
-              <div resource-path="/Documents" resource-name="Documents" class="oc-resource-name oc-text-truncate">
+              <div resource-path="/Documents" resource-name="Documents" resource-type="folder" class="oc-resource-name oc-text-truncate">
                 <!----><span class="oc-resource-basename">Documents</span>
                 <!---->
               </div>


### PR DESCRIPTION
This PR fixes a visual bug with displaying folder names that contain a dot (`.`). Most importantly it also adds a `resource-type` attribute to the oc-resource-name component which is required for testing. Otherwise we don't have a way to detect if a resource is a file or folder.

We need to create a release v3.2.1 from this PR and merge it back to master after the release. Do not merge until the release is done. Current master contains changes that we can't release, yet.