### PR TITLE
Fix nesting on html elements

### DIFF
--- a/changelog/unreleased/enhancement-element-nesting
+++ b/changelog/unreleased/enhancement-element-nesting
@@ -1,0 +1,5 @@
+Enhancement: Element nesting
+
+Fix the nesting for some html elements to make them w3c compliant.
+
+https://github.com/owncloud/owncloud-design-system/pull/1155

--- a/src/components/OCDrop.vue
+++ b/src/components/OCDrop.vue
@@ -127,10 +127,10 @@ export default {
     </p>
     <ul class="uk-list">
       <li>
-        <label><oc-checkbox /> <span class="uk-text-meta">Show Files</span></label>
+        <oc-checkbox /> <span class="uk-text-meta">Show Files</span>
       </li>
       <li>
-        <label><oc-checkbox /> <span class="uk-text-meta">Show Folders</span></label>
+        <oc-checkbox /> <span class="uk-text-meta">Show Folders</span>
       </li>
       <li>
         <oc-search-bar small placeholder="Filter by name" :button="false" />

--- a/src/components/OcAccordionItem.vue
+++ b/src/components/OcAccordionItem.vue
@@ -11,10 +11,10 @@
         @keydown.space="$_ocAccordionItem_toggleExpanded"
         @keydown.enter="$_ocAccordionItem_toggleExpanded"
       >
-        <div class="uk-width-1-1">
-          <oc-grid flex>
+        <span class="uk-width-1-1">
+          <span class="uk-flex uk-flex-middle">
             <oc-icon v-if="icon" :name="icon" class="oc-mr-s" aria-hidden="true" />
-            <div class="uk-width-expand" v-text="title" />
+            <span class="uk-width-expand" v-text="title" />
             <span class="oc-ml-xs oc-icon-l">
               <oc-icon
                 name="expand_more"
@@ -23,12 +23,12 @@
                 size="large"
               />
             </span>
-          </oc-grid>
-          <oc-grid v-if="description">
-            <div v-if="icon" class="oc-icon-m oc-mr-s" />
-            <div class="uk-text-meta">{{ description }}</div>
-          </oc-grid>
-        </div>
+          </span>
+          <span v-if="description">
+            <span v-if="icon" class="oc-icon-m oc-mr-s" />
+            <span class="uk-text-meta">{{ description }}</span>
+          </span>
+        </span>
       </oc-button>
     </component>
     <div

--- a/src/components/resource/OcResourceName.vue
+++ b/src/components/resource/OcResourceName.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <span
     class="oc-resource-name oc-text-truncate"
     v-bind="tooltip"
     :resource-path="fullPath"
@@ -10,7 +10,7 @@
       class="oc-resource-basename"
       v-text="displayName"
     /><span v-if="extension" class="oc-resource-extension" v-text="displayExtension" />
-  </div>
+  </span>
 </template>
 
 <script>

--- a/src/components/resource/__snapshots__/OcResourceName.spec.js.snap
+++ b/src/components/resource/__snapshots__/OcResourceName.spec.js.snap
@@ -1,25 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcResourceName displays full path 1`] = `<div resource-path="images/nature/forest.jpg" resource-name="…/nature/forest.jpg" resource-type="file" uk-tooltip="images/nature/forest.jpg" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">…/nature/</span><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span></div>`;
+exports[`OcResourceName displays full path 1`] = `<span resource-path="images/nature/forest.jpg" resource-name="…/nature/forest.jpg" resource-type="file" uk-tooltip="images/nature/forest.jpg" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">…/nature/</span><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span></span>`;
 
-exports[`OcResourceName displays only direct parent 1`] = `<div resource-path="Documents/notes.txt" resource-name="Documents/notes.txt" resource-type="file" uk-tooltip="Documents/notes.txt" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">Documents/</span><span class="oc-resource-basename">notes</span><span class="oc-resource-extension">.txt</span></div>`;
+exports[`OcResourceName displays only direct parent 1`] = `<span resource-path="Documents/notes.txt" resource-name="Documents/notes.txt" resource-type="file" uk-tooltip="Documents/notes.txt" class="oc-resource-name oc-text-truncate"><span class="oc-resource-path">Documents/</span><span class="oc-resource-basename">notes</span><span class="oc-resource-extension">.txt</span></span>`;
 
 exports[`OcResourceName doesn't add extension to hidden folder 1`] = `
-<div resource-path=".hidden" resource-name=".hidden" resource-type="folder" class="oc-resource-name oc-text-truncate">
-  <!----><span class="oc-resource-basename">.hidden</span>
-  <!---->
-</div>
+<span resource-path=".hidden" resource-name=".hidden" resource-type="folder" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">.hidden</span>
+<!----></span>
 `;
 
-exports[`OcResourceName hides the path if not enabled 1`] = `
-<div resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate">
-  <!----><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span>
-</div>
-`;
+exports[`OcResourceName hides the path if not enabled 1`] = `<span resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">forest</span><span class="oc-resource-extension">.jpg</span></span>`;
 
 exports[`OcResourceName renders folder names with dots completely in the basename 1`] = `
-<div resource-path="folder.with.dots" resource-name="folder.with.dots" resource-type="folder" class="oc-resource-name oc-text-truncate">
-  <!----><span class="oc-resource-basename">folder.with.dots</span>
-  <!---->
-</div>
+<span resource-path="folder.with.dots" resource-name="folder.with.dots" resource-type="folder" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">folder.with.dots</span>
+<!----></span>
 `;

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -38,11 +38,8 @@ exports[`OcTableFiles displays all fields 1`] = `
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-forest" type="checkbox" name="checkbox" aria-checked="false" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-forest" class="oc-invisible-sr oc-cursor-pointer">Select</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><img src="https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg" aria-hidden="true" width="40" height="40" class="oc-resource-preview">
-          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-raw oc-button-raw-color-default">
-              <div resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate">
-                <!----><span class="oc-resource-basename">forest.jpg</span>
-                <!---->
-              </div>
+          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-raw oc-button-raw-color-default"><span resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">forest.jpg</span>
+              <!----></span>
             </button>
             <div class="oc-resource-indicators">
               <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-raw oc-button-raw-color-default" id="files-sharing" uk-tooltip="Shared with other people"><span aria-label="icon" class="oc-icon oc-icon-m oc-icon-passive" aria-hidden="true">function SvgGroup(props) {
@@ -106,11 +103,8 @@ exports[`OcTableFiles displays all fields 1`] = `
     Object.assign({}, props, {'data-file-name': SvgText.name})
   );
 }</span>
-          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-raw oc-button-raw-color-default">
-              <div resource-path="/Documents/notes.txt" resource-name="notes.txt" resource-type="file" class="oc-resource-name oc-text-truncate">
-                <!----><span class="oc-resource-basename">notes.txt</span>
-                <!---->
-              </div>
+          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-raw oc-button-raw-color-default"><span resource-path="/Documents/notes.txt" resource-name="notes.txt" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">notes.txt</span>
+              <!----></span>
             </button>
             <div class="oc-resource-indicators">
               <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-raw oc-button-raw-color-default" id="files-sharing" uk-tooltip="Shared with other people"><span aria-label="icon" class="oc-icon oc-icon-m oc-icon-passive" aria-hidden="true">function SvgGroup(props) {
@@ -174,11 +168,8 @@ exports[`OcTableFiles displays all fields 1`] = `
     Object.assign({}, props, {'data-file-name': SvgFolder.name})
   );
 }</span>
-          <div class="oc-resource-details oc-text-overflow"><a class="oc-text-overflow">
-              <div resource-path="/Documents" resource-name="Documents" resource-type="folder" class="oc-resource-name oc-text-truncate">
-                <!----><span class="oc-resource-basename">Documents</span>
-                <!---->
-              </div>
+          <div class="oc-resource-details oc-text-overflow"><a class="oc-text-overflow"><span resource-path="/Documents" resource-name="Documents" resource-type="folder" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">Documents</span>
+              <!----></span>
             </a>
             <div class="oc-resource-indicators">
               <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-raw oc-button-raw-color-default" id="files-sharing" uk-tooltip="Shared with other people"><span aria-label="icon" class="oc-icon oc-icon-m oc-icon-passive" aria-hidden="true">function SvgGroup(props) {


### PR DESCRIPTION
Fixes the nesting issues coming from the ODS mentioned in https://github.com/owncloud/web/issues/4345

For now this should be all in the ODS. However, it is possible some more adjustments are needed. Need to dig into Oc Web first 👀 

On a side note: Feels a bit weird to use flexbox on a `<span>` element in `OcAccordion`. But it seems to be legit. Keeping the `<div>` tags would require a change in the parent component, which currently can be any `<h1-6>` element.