### PR TITLE
Fix avatar group tooltip which only has links

### DIFF
--- a/changelog/3.2.2_2021-03-22/bugfix-links-in-avatar-group
+++ b/changelog/3.2.2_2021-03-22/bugfix-links-in-avatar-group
@@ -1,0 +1,5 @@
+Bugfix: Remove leading comma from link avatar group tooltip
+
+We fixed a bug in the oc-avatar-group component, which showed a leading ", " in its tooltip in case it was only about links.
+
+https://github.com/owncloud/owncloud-design-system/pull/1165

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owncloud-design-system",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "ownCloud Design System is based on VueDesign Systems and is used to design ownCloud UI components",
   "author": "ownClouders",
   "main": "dist/system/system.js",

--- a/src/components/avatars/OcAvatarGroup.vue
+++ b/src/components/avatars/OcAvatarGroup.vue
@@ -43,7 +43,7 @@ export default {
 
   props: {
     /**
-     * Users to be displayed with avatars
+     * Users and public links to be displayed with avatars
      */
     users: {
       type: Array,
@@ -82,11 +82,13 @@ export default {
 
     tooltip() {
       if (this.isTooltipDisplayed) {
-        let tooltip = this.avatars.map(user => user.displayName).join(", ")
+        const names = this.avatars.map(user => user.displayName)
 
         if (this.links.length > 0) {
-          tooltip += ", " + this.links.map(link => link.name).join(", ")
+          names.push(...this.links.map(link => link.name))
         }
+
+        let tooltip = names.join(", ")
 
         if (this.isOverlapping) {
           tooltip += ` +${this.users.length - this.maxDisplayed}`


### PR DESCRIPTION
This PR fixes the tooltip of the oc-avatar-group in case it was only displaying links.

We'll need to create a release from this branch and merge it back to master after the release. Do not merge until then.