### PR TITLE
Make alert component a11y-compliant

### DIFF
--- a/changelog/unreleased/enhancement-alert-accessibility
+++ b/changelog/unreleased/enhancement-alert-accessibility
@@ -1,0 +1,5 @@
+Enhancement: Make alert component a11y-compliant
+
+It is now possible to reach and submit the "close"-button of an alert via keyboard. This change also removes the "uk-close" icon as it is not a11y-compliant.
+
+https://github.com/owncloud/owncloud-design-system/pull/1166

--- a/src/components/OCAlert.vue
+++ b/src/components/OCAlert.vue
@@ -1,6 +1,15 @@
 <template>
   <div class="oc-alert" :class="_class" uk-alert>
-    <a v-if="!noClose" class="uk-alert-close" uk-close @click="$_ocAlert_onClose" />
+    <oc-button
+      v-if="!noClose"
+      class="uk-alert-close"
+      variation="raw"
+      color="text"
+      :aria-label="$gettext('Close alert')"
+      @click="onClose"
+    >
+      <oc-icon name="close" size="small"></oc-icon>
+    </oc-button>
     <slot />
   </div>
 </template>
@@ -44,7 +53,7 @@ export default {
     },
   },
   methods: {
-    $_ocAlert_onClose(val) {
+    onClose(val) {
       /**
        * The user closed / hid the alert
        * @event close

--- a/src/components/__snapshots__/OCAlert.spec.js.snap
+++ b/src/components/__snapshots__/OCAlert.spec.js.snap
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OCAlert displays correct message 1`] = `
-<div uk-alert="" class="oc-alert oc-alert"><a uk-close="" class="uk-alert-close"></a>
+<div uk-alert="" class="oc-alert oc-alert">
+  <oc-button variation="raw" color="text" aria-label="Close alert" class="uk-alert-close">
+    <oc-icon name="close" size="small"></oc-icon>
+  </oc-button>
   <p class="slot-message">Test message</p>
 </div>
 `;
@@ -14,7 +17,10 @@ exports[`OCAlert hides the close button if disabled 1`] = `
 `;
 
 exports[`OCAlert sets correct variation 1`] = `
-<div uk-alert="" class="oc-alert oc-alert uk-alert-primary"><a uk-close="" class="uk-alert-close"></a>
+<div uk-alert="" class="oc-alert oc-alert uk-alert-primary">
+  <oc-button variation="raw" color="text" aria-label="Close alert" class="uk-alert-close">
+    <oc-icon name="close" size="small"></oc-icon>
+  </oc-button>
   <p class="slot-message">Test message</p>
 </div>
 `;


### PR DESCRIPTION
Similar to the changes in https://github.com/owncloud/owncloud-design-system/pull/1164

* Make "close"-button of an alert accessible via keyboard
* Remove the "uk-close" icon as it is not a11y-compliant