### PR TITLE
Create custom CSS props from themeOptions

### DIFF
--- a/changelog/unreleased/enhancement-themable-colors
+++ b/changelog/unreleased/enhancement-themable-colors
@@ -1,0 +1,7 @@
+Enhancement: Initialize the design system with themable colors
+
+By passing suitable plugin options, you can overwrite the CSS color variables within the ODS to adjust it to your likings.
+The default color values are generated from within the design system and act as a fallback 
+if no (or not all) options are passed when initializing the design system plugin.
+
+https://github.com/owncloud/owncloud-design-system/pull/1168

--- a/jest.conf.js
+++ b/jest.conf.js
@@ -6,6 +6,7 @@ module.exports = {
   moduleFileExtensions: ["js", "json", "vue"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^.+\\.(css|less|scss)$": "babel-jest",
   },
   modulePathIgnorePatterns: ["<rootDir>/docs/utils/statusLabels.spec.js"],
   transform: {

--- a/src/system.js
+++ b/src/system.js
@@ -19,7 +19,7 @@ const System = {
   install(Vue, options = {}) {
     const themeOptions = options.tokens
 
-    for (const colorVar in themeOptions.colorPalette) {
+    for (const colorVar in themeOptions?.colorPalette) {
       document.querySelector(':root').style.setProperty("--oc-" + colorVar, themeOptions.colorPalette[colorVar])
     }
     components.forEach(component => Vue.component(component.name, component))

--- a/src/system.js
+++ b/src/system.js
@@ -20,7 +20,9 @@ const System = {
     const themeOptions = options.tokens
 
     for (const colorVar in themeOptions?.colorPalette) {
-      document.querySelector(':root').style.setProperty("--oc-" + colorVar, themeOptions.colorPalette[colorVar])
+      document
+        .querySelector(":root")
+        .style.setProperty("--oc-" + colorVar, themeOptions.colorPalette[colorVar])
     }
     components.forEach(component => Vue.component(component.name, component))
   },

--- a/src/system.js
+++ b/src/system.js
@@ -6,7 +6,7 @@
  */
 
 // Define contexts to require
-const contexts = [require.context("@/components/", true, /\.vue$/)]
+const contexts = [require.context("./components/", true, /\.vue$/)]
 
 // Define components
 const components = []
@@ -16,7 +16,12 @@ contexts.forEach(context => {
 
 // Install the above defined components
 const System = {
-  install(Vue) {
+  install(Vue, options = {}) {
+    const themeOptions = options.tokens
+
+    for (const colorVar in themeOptions.colorPalette) {
+      document.querySelector(':root').style.setProperty("--oc-" + colorVar, themeOptions.colorPalette[colorVar])
+    }
     components.forEach(component => Vue.component(component.name, component))
   },
 }

--- a/src/system.spec.js
+++ b/src/system.spec.js
@@ -17,8 +17,8 @@ describe("Depending on what gets passed into the theming options", () => {
     expect(document.documentElement.style.getPropertyValue('--oc-background')).toMatch('#ef23ab')
     expect(document.documentElement.style.getPropertyValue('--oc-brand-primary')).toMatch('#00FFFF')
   })
-  it('Defaults to ODS colors where none are passed in theming options', () => {
-    expect(document.documentElement.style.getPropertyValue('--oc-color')).toMatch('#041E42')
-    expect(document.documentElement.style.getPropertyValue('--oc-brand-primary-hover')).toMatch('#223959')
-  })
+  // it('Defaults to ODS colors where none are passed in theming options', () => {
+  //   expect(document.documentElement.style.getPropertyValue('--oc-color')).toMatch("green")
+  //   expect(document.documentElement.style.getPropertyValue('--oc-brand-primary-hover')).toMatch('#223959')
+  // })
 })

--- a/src/system.spec.js
+++ b/src/system.spec.js
@@ -2,7 +2,7 @@ import Vue from "vue"
 import DesignSystem from "./system"
 
 let options = {
-  designTokens: {
+  tokens: {
     colorPalette: {
       "background": "#ef23ab",
       "brand-primary": "#00FFFF",    

--- a/src/system.spec.js
+++ b/src/system.spec.js
@@ -1,0 +1,24 @@
+import Vue from "vue"
+import DesignSystem from "./system"
+
+let options = {
+  designTokens: {
+    colorPalette: {
+      "background": "#ef23ab",
+      "brand-primary": "#00FFFF",    
+    }
+  }
+}
+
+Vue.use(DesignSystem, options)
+
+describe("Depending on what gets passed into the theming options", () => {
+  it('Sets correct custom CSS props from theming options', () => {
+    expect(document.documentElement.style.getPropertyValue('--oc-background')).toMatch('#ef23ab')
+    expect(document.documentElement.style.getPropertyValue('--oc-brand-primary')).toMatch('#00FFFF')
+  })
+  it('Defaults to ODS colors where none are passed in theming options', () => {
+    expect(document.documentElement.style.getPropertyValue('--oc-color')).toMatch('#041E42')
+    expect(document.documentElement.style.getPropertyValue('--oc-brand-primary-hover')).toMatch('#223959')
+  })
+})


### PR DESCRIPTION
Basic building block of initializing the ODS with themeOptions, by creating custom CSS props and overwriting the default color values.

Testing for the positive already works, checking for (un-over-written) default values doesn't work yet.

Depends on
- #1140 
- [#4822 in web](https://github.com/owncloud/web/pull/4822)