### PR TITLE
Drop placeholders in favor of descriptionMessages in OcModal

### DIFF
--- a/changelog/unreleased/enhancement-omit-placeholders-in-modal
+++ b/changelog/unreleased/enhancement-omit-placeholders-in-modal
@@ -1,4 +1,4 @@
-Enhancement: Turn placeholders in OcModal into descriptionMessages (accessbility gain)
+Enhancement: Turn placeholders in OcModal into descriptionMessages
 
 We have dropped the support for placeholders in the `<oc-text-input>` component.
 As this component is used inside OcModal, this change also drops placeholder support 

--- a/changelog/unreleased/enhancement-remove-placeholders-from-ocmodal
+++ b/changelog/unreleased/enhancement-remove-placeholders-from-ocmodal
@@ -1,0 +1,8 @@
+Enhancement: Turn placeholders in OcModal into descriptionMessages (accessbility gain)
+
+We have dropped the support for placeholders in the `<oc-text-input>` component.
+As this component is used inside OcModal, this change also drops placeholder support 
+and adds the possibilty to instead make use of a descriptionMessage (which is only being 
+display if no inputError is present).
+
+https://github.com/owncloud/owncloud-design-system/pull/1172

--- a/src/components/OcModal.vue
+++ b/src/components/OcModal.vue
@@ -17,7 +17,7 @@
           class="oc-modal-body-input"
           :error-message="inputError"
           :label="inputLabel"
-          :placeholder="inputPlaceholder"
+          :description-message="inputDescription"
           :disabled="inputDisabled"
           :fix-message-line="true"
           @input="inputOnInput"
@@ -207,9 +207,9 @@ export default {
       default: null,
     },
     /**
-     * Placeholder of the input
+     * Additional description message for the input field
      */
-    inputPlaceholder: {
+    inputDescription: {
       type: String,
       required: false,
       default: null,
@@ -313,7 +313,7 @@ export default {
     :hasInput="true"
     inputValue="New folder"
     inputLabel="Folder name"
-    inputPlaceholder="Enter a folder name"
+    inputDescription="Enter a folder name"
     inputError="This name is already taken"
     class="oc-mb-l uk-position-relative"
   />


### PR DESCRIPTION
Making the behavior consistent with other usages of input-fields within the ODS