### PR TITLE
Fix links count in avatar group

### DIFF
--- a/changelog/unreleased/bugfix-links-in-avatar-group
+++ b/changelog/unreleased/bugfix-links-in-avatar-group
@@ -1,0 +1,5 @@
+Bugfix: Links in oc-avatar-group
+
+The oc-avatar-group was showing all link, ignoring the `maxDisplayed` property. We fixed that by properly cutting off the items used for rendering avatars.
+
+https://github.com/owncloud/owncloud-design-system/pull/1184

--- a/src/components/avatars/OcAvatarGroup.spec.js
+++ b/src/components/avatars/OcAvatarGroup.spec.js
@@ -11,6 +11,11 @@ const users = [
       "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
   },
   {
+    id: "link0",
+    link: "fake url content",
+    name: "link 0",
+  },
+  {
     id: "marie",
     username: "marie",
     displayName: "Marie",
@@ -22,6 +27,11 @@ const users = [
     username: "john",
     displayName: "John Richards Emperor of long names",
   },
+  {
+    id: "link1",
+    link: "fake url content",
+    name: "link 1",
+  }
 ]
 
 describe("OcAvatarGroup", () => {
@@ -34,7 +44,7 @@ describe("OcAvatarGroup", () => {
       },
     })
 
-    expect(wrapper.attributes()["uk-tooltip"]).toMatch("Bob, Marie +1")
+    expect(wrapper.attributes()["uk-tooltip"]).toMatch("Bob, Marie +3")
     expect(wrapper).toMatchSnapshot()
   })
 
@@ -46,5 +56,30 @@ describe("OcAvatarGroup", () => {
     })
 
     expect(wrapper.attributes()["uk-tooltip"]).toBeFalsy()
+  })
+
+  it("prefers avatars over links when maxDisplayed is exceeded", () => {
+    const wrapper = shallowMount(Group, {
+      propsData: {
+        users,
+        maxDisplayed: 3,
+        isTooltipDisplayed: true,
+      }
+    })
+
+    expect(wrapper.attributes()["uk-tooltip"]).toMatch("Bob, Marie, John Richards Emperor of long names +2")
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it("shows avatars first and links last", () => {
+    const wrapper = shallowMount(Group, {
+      propsData: {
+        users,
+        isTooltipDisplayed: true,
+      }
+    })
+
+    expect(wrapper.attributes()["uk-tooltip"]).toMatch("Bob, Marie, John Richards Emperor of long names, link 0, link 1")
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/avatars/OcAvatarGroup.vue
+++ b/src/components/avatars/OcAvatarGroup.vue
@@ -101,19 +101,22 @@ export default {
     },
 
     avatars() {
-      if (this.maxDisplayed) {
-        return this.users.slice(0, this.maxDisplayed).filter(user => !user.link)
+      const a = this.users.filter(u => !u.link)
+      if (!this.isOverlapping) {
+        return a
       }
-
-      return this.users.filter(user => !user.link)
+      return a.slice(0, this.maxDisplayed)
     },
 
     links() {
-      if (this.maxDisplayed && this.avatars.length === this.maxDisplayed) {
+      const a = this.users.filter(u => !!u.link)
+      if (!this.isOverlapping) {
+        return a
+      }
+      if (this.maxDisplayed <= this.avatars.length) {
         return []
       }
-
-      return this.users.filter(user => user.link)
+      return a.slice(0, this.maxDisplayed - this.avatars.length)
     },
   },
 }

--- a/src/components/avatars/__snapshots__/OcAvatarGroup.spec.js.snap
+++ b/src/components/avatars/__snapshots__/OcAvatarGroup.spec.js.snap
@@ -1,10 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OcAvatarGroup displays tooltip 1`] = `
-<div uk-tooltip="Bob, Marie +1" class="oc-avatar-group">
+<div uk-tooltip="Bob, Marie +3" class="oc-avatar-group">
   <oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="bob" accessiblelabel="Bob" width="30"></oc-avatar-stub>
   <oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="marie" accessiblelabel="Marie" width="30"></oc-avatar-stub>
   <!---->
-  <oc-avatar-count-stub count="1" size="30"></oc-avatar-count-stub>
+  <oc-avatar-count-stub count="3" size="30"></oc-avatar-count-stub>
+</div>
+`;
+
+exports[`OcAvatarGroup prefers avatars over links when maxDisplayed is exceeded 1`] = `
+<div uk-tooltip="Bob, Marie, John Richards Emperor of long names +2" class="oc-avatar-group">
+  <oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="bob" accessiblelabel="Bob" width="30"></oc-avatar-stub>
+  <oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="marie" accessiblelabel="Marie" width="30"></oc-avatar-stub>
+  <oc-avatar-stub src="" username="john" accessiblelabel="John Richards Emperor of long names" width="30"></oc-avatar-stub>
+  <!---->
+  <oc-avatar-count-stub count="2" size="30"></oc-avatar-count-stub>
+</div>
+`;
+
+exports[`OcAvatarGroup shows avatars first and links last 1`] = `
+<div uk-tooltip="Bob, Marie, John Richards Emperor of long names, link 0, link 1" class="oc-avatar-group">
+  <oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="bob" accessiblelabel="Bob" width="30"></oc-avatar-stub>
+  <oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="marie" accessiblelabel="Marie" width="30"></oc-avatar-stub>
+  <oc-avatar-stub src="" username="john" accessiblelabel="John Richards Emperor of long names" width="30"></oc-avatar-stub>
+  <oc-avatar-link-stub name="link 0" accessiblelabel="link 0"></oc-avatar-link-stub>
+  <oc-avatar-link-stub name="link 1" accessiblelabel="link 1"></oc-avatar-link-stub>
+  <!---->
 </div>
 `;


### PR DESCRIPTION
The oc-avatar-group was showing all link, ignoring the `maxDisplayed` property. Fixed by properly cutting off the items used for rendering avatars. Added some tests to verify the behaviour at least on the tooltips.