### PR TITLE
use html-loader for svg images

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -84,10 +84,7 @@ module.exports = {
       },
       {
         test: /\.svg$/,
-        loader: "url-loader",
-        options: {
-          esModule: false,
-        },
+        loader: "html-loader",
       },
       {
         test: /\.(mp4|webm|ogg|mp3|wav|flac|aac)(\?.*)?$/,

--- a/changelog/unreleased/bugfix-oc-icon-loading
+++ b/changelog/unreleased/bugfix-oc-icon-loading
@@ -1,7 +1,7 @@
 Bugfix: Embed svg images
-
 We've changed the way how svg images get loaded in oc-icon.
-Before this, svg images where transformed to data url's by webpack.
-Now we use require to inline them which prevents the browser to do a XMLHttpRequest and no additional tweaking of content-security-police is required anymore.
+Before this, svg images where transformed to data urls by webpack.
+Now, we use require to inline them, which prevents the browser from
+doing a XMLHttpRequest that can lead to problems with the content-security-police.
 
 https://github.com/owncloud/owncloud-design-system/pull/1198

--- a/changelog/unreleased/bugfix-oc-icon-loading
+++ b/changelog/unreleased/bugfix-oc-icon-loading
@@ -1,0 +1,7 @@
+Bugfix: Embed svg images
+
+We've changed the way how svg images get loaded in oc-icon.
+Before this, svg images where transformed to data url's by webpack.
+Now we use require to inline them which prevents the browser to do a XMLHttpRequest and no additional tweaking of content-security-police is required anymore.
+
+https://github.com/owncloud/owncloud-design-system/pull/1198

--- a/src/components/OcIcon.vue
+++ b/src/components/OcIcon.vue
@@ -11,7 +11,7 @@
     @click="onClick"
   >
     <inline-svg
-      :src="svgPath"
+      :src="name"
       :transform-source="transformSvgElement"
       :aria-hidden="accessibleLabel === '' ? 'true' : null"
       :aria-labelledby="accessibleLabel === '' ? null : svgTitleId"
@@ -39,6 +39,23 @@ import { getSizeClass } from "../utils/sizeClasses"
  *  3. set `focusable` to `false`.
  *  4. remove or empty all aria-related properties such as labels.
  */
+
+/**
+ * InlineSvg by default expects the src to be a url, because we inline the SVG's this won't work.
+ * the download patch takes care of this by overwriting the native functionality and makes it compatible
+ */
+InlineSvg.methods.download = name => {
+  return new Promise((resolve, reject) => {
+    let svg
+    try {
+      svg = require("../assets/icons/" + name + ".svg")
+    } catch (e) {
+      return reject(e)
+    }
+    resolve(new DOMParser().parseFromString(svg, "image/svg+xml").documentElement)
+  })
+}
+
 export default {
   name: "OcIcon",
   status: "review",
@@ -94,9 +111,6 @@ export default {
     },
   },
   computed: {
-    svgPath() {
-      return require("../assets/icons/" + this.name + ".svg")
-    },
     svgTitleId() {
       return uniqueId("oc-icon-title-")
     },
@@ -195,55 +209,55 @@ export default {
   </section>
 </template>
 <script>
-export default {
-  computed: {
-    variations() {
-      return [{
-        id: "9828-4946-1277-7396",
-        name: "passive",
-      }, {
-        id: "7828-3285-4787-2127",
-        name: "primary",
-      }, {
-        id: "8376-8902-1172-2699",
-        name: "danger",
-      }, {
-        id: "4935-2899-4697-2615",
-        name: "success",
-      }, {
-        id: "2769-7633-8478-1257",
-        name: "warning",
-      }, {
-        id: "2324-8956-9042",
-        name: "inverse",
-      }]
+  export default {
+    computed: {
+      variations() {
+        return [{
+          id: "9828-4946-1277-7396",
+          name: "passive",
+        }, {
+          id: "7828-3285-4787-2127",
+          name: "primary",
+        }, {
+          id: "8376-8902-1172-2699",
+          name: "danger",
+        }, {
+          id: "4935-2899-4697-2615",
+          name: "success",
+        }, {
+          id: "2769-7633-8478-1257",
+          name: "warning",
+        }, {
+          id: "2324-8956-9042",
+          name: "inverse",
+        }]
+      },
+      sizes() {
+        return [{
+          id: "6343-1519-1328-9822",
+          name: "xsmall",
+        }, {
+          id: "9041-7650-9126-4291",
+          name: "small",
+        }, {
+          id: "9665-6662-8676-4866",
+          name: "medium",
+        }, {
+          id: "9130-7140-3870-5438",
+          name: "large",
+        }, {
+          id: "5022-6406-9625-7093",
+          name: "xlarge",
+        }, {
+          id: "9337-2657-4486-1014",
+          name: "xxlarge",
+        }, {
+          id: "8234-4209-7553-9253",
+          name: "xxxlarge",
+        }]
+      },
     },
-    sizes() {
-      return [{
-        id: "6343-1519-1328-9822",
-        name: "xsmall",
-      }, {
-        id: "9041-7650-9126-4291",
-        name: "small",
-      }, {
-        id: "9665-6662-8676-4866",
-        name: "medium",
-      }, {
-        id: "9130-7140-3870-5438",
-        name: "large",
-      }, {
-        id: "5022-6406-9625-7093",
-        name: "xlarge",
-      }, {
-        id: "9337-2657-4486-1014",
-        name: "xxlarge",
-      }, {
-        id: "8234-4209-7553-9253",
-        name: "xxxlarge",
-      }]
-    },
-  },
-}
+  }
 </script>
 ```
 </docs>

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -42,7 +42,7 @@ exports[`OcTableFiles displays all fields 1`] = `
               <!----></span>
             </button>
             <div class="oc-resource-indicators">
-              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><!----></span></div>
+              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-1"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-1">Shared via link</title>6:1: text data outside of root node.</svg></span></div>
             </div>
           </div>
         </div>
@@ -76,18 +76,18 @@ exports[`OcTableFiles displays all fields 1`] = `
         1 day ago
       </td>
       <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-actions">
-        <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></button></div>
+        <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button></div>
       </td>
     </tr>
     <tr class="oc-tbody-tr oc-tbody-tr-notes" style="height: 64px;">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-notes" type="checkbox" name="checkbox" aria-checked="false" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-notes" class="oc-invisible-sr oc-cursor-pointer">Select</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><!----></span>
+        <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span>
           <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw"><span resource-path="/Documents/notes.txt" resource-name="notes.txt" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">notes.txt</span>
               <!----></span>
             </button>
             <div class="oc-resource-indicators">
-              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><!----></span></div>
+              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-2"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-2">Shared via link</title>6:1: text data outside of root node.</svg></span></div>
             </div>
           </div>
         </div>
@@ -121,18 +121,18 @@ exports[`OcTableFiles displays all fields 1`] = `
         1 day ago
       </td>
       <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-actions">
-        <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></button></div>
+        <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button></div>
       </td>
     </tr>
     <tr class="oc-tbody-tr oc-tbody-tr-documents" style="height: 64px;">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-documents" type="checkbox" name="checkbox" aria-checked="false" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-documents" class="oc-invisible-sr oc-cursor-pointer">Select</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><!----></span>
+        <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span>
           <div class="oc-resource-details oc-text-overflow"><a class="oc-text-overflow"><span resource-path="/Documents" resource-name="Documents" resource-type="folder" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">Documents</span>
               <!----></span>
             </a>
             <div class="oc-resource-indicators">
-              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><!----></span></div>
+              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-3"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-3">Shared via link</title>6:1: text data outside of root node.</svg></span></div>
             </div>
           </div>
         </div>
@@ -166,7 +166,7 @@ exports[`OcTableFiles displays all fields 1`] = `
         1 day ago
       </td>
       <td class="oc-td oc-table-cell oc-table-cell-align-right oc-table-cell-align-middle oc-table-cell-width-auto oc-text-nowrap oc-table-data-cell oc-table-data-cell-actions">
-        <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><!----></span></button></div>
+        <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button></div>
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
the pr changed the way how svg images get loaded in oc-icon.
Before this, svg images where transformed to data url's by webpack.
Now we use require to inline them which prevents the browser to do a XMLHttpRequest and no additional tweaking of content-security-police is required anymore.
