### PR TITLE
Add translations to dist folder when building

### DIFF
--- a/build/webpack.system.conf.js
+++ b/build/webpack.system.conf.js
@@ -76,6 +76,10 @@ const webpackConfig = merge(baseWebpackConfig, {
             ignore: [".*"],
           },
         },
+        {
+          from: path.resolve(__dirname, "../l10n/translations.json"),
+          to: config.system.assetsSubDirectory,
+        },
       ],
     }),
   ],

--- a/changelog/unreleased/enhancement-export-translations
+++ b/changelog/unreleased/enhancement-export-translations
@@ -1,0 +1,7 @@
+Enhancement: Export translations
+
+Some ODS components depend on translations and they correctly get pulled from Transifex into 
+`l10n/translations.json`, yet we never exported them for other projects to use. Now, they get 
+copied into the `dist` folder and can be imported and used alongside the styles and components.
+
+https://github.com/owncloud/owncloud-design-system/pull/1201


### PR DESCRIPTION
To test this locally, run `yarn build:system` and check that `dist/system/translations.json` exists