### PR TITLE
Use newer nodejs images in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -23,7 +23,7 @@ def testing(ctx):
         'steps': [
             {
                 'name': 'dependencies',
-                'image': 'owncloudci/nodejs:15',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn install'
@@ -31,7 +31,7 @@ def testing(ctx):
             },
             {
                 'name': 'eslint',
-                'image': 'owncloudci/nodejs:15',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn lint:eslint',
@@ -40,7 +40,7 @@ def testing(ctx):
             },
             {
                 'name': 'stylelint',
-                'image': 'owncloudci/nodejs:15',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn lint:stylelint',
@@ -49,7 +49,7 @@ def testing(ctx):
             },
             {
                 'name': 'build docs',
-                'image': 'owncloudci/nodejs:15',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn install',
@@ -59,7 +59,7 @@ def testing(ctx):
             },
             {
                 'name': 'build system',
-                'image': 'owncloudci/nodejs:15',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn install',
@@ -69,7 +69,7 @@ def testing(ctx):
             },
             {
                 'name': 'unit tests',
-                'image': 'owncloudci/nodejs:15',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn install',
@@ -114,7 +114,7 @@ def build(ctx):
         'steps': [
             {
                 'name': 'build-docs',
-                'image': 'webhippie/nodejs:latest',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn install',
@@ -123,7 +123,7 @@ def build(ctx):
             },
             {
                 'name': 'build-system',
-                'image': 'webhippie/nodejs:latest',
+                'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn install',


### PR DESCRIPTION
Publish of `v6.0.0` failed in CI with an error that I suspect to be due to an old node version in the CI pipeline

Error:
```sh
SyntaxError: Unexpected token '.'

in

color.lighten(parseInt(attributes?.transform?.lighten) || 0)
```

in https://drone.owncloud.com/owncloud/owncloud-design-system/2527/2/2

We used webhippie's latest node image which was updated 10 months ago anyways: https://hub.docker.com/r/webhippie/nodejs/tags?page=1&ordering=last_updated
