### PR TITLE
Enhance oc-breadcrumb a11y 

### DIFF
--- a/changelog/unreleased/change-oc-breadcrumb-a11y
+++ b/changelog/unreleased/change-oc-breadcrumb-a11y
@@ -1,0 +1,8 @@
+Change: Improve accessibility of oc-breadcrumb component
+
+In order to enhance accessibility oc breadcrumb has been wrapped into a <nav> tag.
+The <ul> element changed to <ol> element, furthermore aria-current=page applies to the last item and
+the default home breadcrumb has been removed.
+Keyboard navigation has been fixed.
+
+https://github.com/owncloud/owncloud-design-system/pull/1228

--- a/src/components/__snapshots__/OcBreadcrumb.spec.js.snap
+++ b/src/components/__snapshots__/OcBreadcrumb.spec.js.snap
@@ -1,61 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OcBreadcrumb displays all items 1`] = `
-<div class="oc-breadcrumb oc-breadcrumb-default">
-  <ul class="oc-breadcrumb-list">
+<nav class="oc-breadcrumb oc-breadcrumb-default">
+  <ol class="oc-breadcrumb-list">
     <li class="oc-breadcrumb-list-item">
       <router-link-stub tag="a" to="[object Object]">First folder</router-link-stub>
     </li>
-    <li class="oc-breadcrumb-list-item"><a>Subfolder</a></li>
+    <li class="oc-breadcrumb-list-item">
+      <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="center" gapsize="medium">
+        Subfolder
+      </oc-button-stub>
+    </li>
     <li class="oc-breadcrumb-list-item">
       <router-link-stub tag="a" to="[object Object]">Deep</router-link-stub>
     </li>
-    <li class="oc-breadcrumb-list-item"><span>Deeper ellipsize in responsive mode</span></li>
-  </ul>
-  <div class="oc-breadcrumb-drop"><label class="oc-breadcrumb-drop-label"><span class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
+    <li class="oc-breadcrumb-list-item"><span aria-current="page">Deeper ellipsize in responsive mode</span></li>
+  </ol>
+  <div class="oc-breadcrumb-drop"><label tabindex="0" class="oc-breadcrumb-drop-label"><span aria-current="page" class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
       <oc-icon-stub name="expand_more" accessiblelabel="Expand more" type="span" size="medium" variation="passive" class="oc-breadcrumb-drop-label-icon"></oc-icon-stub>
     </label>
     <oc-drop-stub dropid="oc-drop-2" toggle="- *" position="bottom-left" mode="click" options="[object Object]">
-      <ul class="uk-nav uk-nav-default">
+      <ol class="uk-nav uk-nav-default">
         <li>
           <router-link-stub tag="a" to="[object Object]">Deep</router-link-stub>
         </li>
-        <li><a>Subfolder</a></li>
+        <li>
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="left" gapsize="medium">Subfolder</oc-button-stub>
+        </li>
         <li>
           <router-link-stub tag="a" to="[object Object]">First folder</router-link-stub>
         </li>
-      </ul>
+      </ol>
     </oc-drop-stub>
   </div>
-</div>
+</nav>
 `;
 
 exports[`OcBreadcrumb sets correct variation 1`] = `
-<div class="oc-breadcrumb oc-breadcrumb-lead">
-  <ul class="oc-breadcrumb-list">
+<nav class="oc-breadcrumb oc-breadcrumb-lead">
+  <ol class="oc-breadcrumb-list">
     <li class="oc-breadcrumb-list-item">
       <router-link-stub tag="a" to="[object Object]">First folder</router-link-stub>
     </li>
-    <li class="oc-breadcrumb-list-item"><a>Subfolder</a></li>
+    <li class="oc-breadcrumb-list-item">
+      <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="center" gapsize="medium">
+        Subfolder
+      </oc-button-stub>
+    </li>
     <li class="oc-breadcrumb-list-item">
       <router-link-stub tag="a" to="[object Object]">Deep</router-link-stub>
     </li>
-    <li class="oc-breadcrumb-list-item"><span>Deeper ellipsize in responsive mode</span></li>
-  </ul>
-  <div class="oc-breadcrumb-drop"><label class="oc-breadcrumb-drop-label"><span class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
+    <li class="oc-breadcrumb-list-item"><span aria-current="page">Deeper ellipsize in responsive mode</span></li>
+  </ol>
+  <div class="oc-breadcrumb-drop"><label tabindex="0" class="oc-breadcrumb-drop-label"><span aria-current="page" class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
       <oc-icon-stub name="expand_more" accessiblelabel="Expand more" type="span" size="medium" variation="passive" class="oc-breadcrumb-drop-label-icon"></oc-icon-stub>
     </label>
     <oc-drop-stub dropid="oc-drop-1" toggle="- *" position="bottom-left" mode="click" options="[object Object]">
-      <ul class="uk-nav uk-nav-default">
+      <ol class="uk-nav uk-nav-default">
         <li>
           <router-link-stub tag="a" to="[object Object]">Deep</router-link-stub>
         </li>
-        <li><a>Subfolder</a></li>
+        <li>
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="left" gapsize="medium">Subfolder</oc-button-stub>
+        </li>
         <li>
           <router-link-stub tag="a" to="[object Object]">First folder</router-link-stub>
         </li>
-      </ul>
+      </ol>
     </oc-drop-stub>
   </div>
-</div>
+</nav>
 `;


### PR DESCRIPTION
* Replace unordered list element with ordered list element
* Add nav surrounding tag
* Add aria-current='page' to the last element 
* Remove default home breadcrumb 
* Allow keyboard navigation (as well for mobile)

fixes https://github.com/owncloud/owncloud-design-system/issues/866
fixes https://github.com/owncloud/owncloud-design-system/issues/849
fixes https://github.com/owncloud/owncloud-design-system/issues/1170