### PR TITLE
Enhance accessibility for the files table and its contents

### DIFF
--- a/changelog/unreleased/enhancement-files-table-a11y
+++ b/changelog/unreleased/enhancement-files-table-a11y
@@ -1,0 +1,8 @@
+Enhancement: Files table accessibility
+
+* Add accessible description in case a resource link opens in a new window
+* Add accessible description for status indicators
+* Adjust some of the labels to make them more descriptive
+* Fix broken outline on directories
+
+https://github.com/owncloud/owncloud-design-system/pull/1229

--- a/src/components/OcStatusIndicators.vue
+++ b/src/components/OcStatusIndicators.vue
@@ -7,6 +7,7 @@
         :key="indicator.id"
         class="oc-status-indicators-indicator"
         :aria-label="indicator.label"
+        :aria-describedby="getIndicatorDescriptionId(indicator)"
         :uk-tooltip="indicator.label"
         variation="passive"
         appearance="raw"
@@ -22,8 +23,16 @@
         class="oc-status-indicators-indicator"
         :name="indicator.icon"
         :accessible-label="indicator.label"
+        :aria-describedby="getIndicatorDescriptionId(indicator)"
         :uk-tooltip="indicator.label"
         variation="passive"
+      />
+      <span
+        v-if="getIndicatorDescriptionId(indicator)"
+        :id="getIndicatorDescriptionId(indicator)"
+        :key="indicator.id"
+        class="oc-invisible-sr"
+        v-text="indicator.accessibleDescription"
       />
     </template>
   </div>
@@ -32,6 +41,7 @@
 <script>
 import OcIcon from "./OcIcon.vue"
 import OcButton from "./OcButton.vue"
+import uniqueId from "../utils/uniqueId"
 
 /**
  * Status indicators which can be attatched to a resource
@@ -71,6 +81,17 @@ export default {
   methods: {
     hasHandler(indicator) {
       return Object.prototype.hasOwnProperty.call(indicator, "handler")
+    },
+    getIndicatorDescriptionId(indicator) {
+      if (!indicator.accessibleDescription) {
+        return null
+      }
+
+      if (!indicator.accessibleDescriptionId) {
+        indicator.accessibleDescriptionId = uniqueId("oc-indicator-description-")
+      }
+
+      return indicator.accessibleDescriptionId
     },
   },
 }

--- a/src/components/OcStatusIndicators.vue
+++ b/src/components/OcStatusIndicators.vue
@@ -78,6 +78,12 @@ export default {
     },
   },
 
+  data() {
+    return {
+      accessibleDescriptionIds: {},
+    }
+  },
+
   methods: {
     hasHandler(indicator) {
       return Object.prototype.hasOwnProperty.call(indicator, "handler")
@@ -87,11 +93,11 @@ export default {
         return null
       }
 
-      if (!indicator.accessibleDescriptionId) {
-        indicator.accessibleDescriptionId = uniqueId("oc-indicator-description-")
+      if (!this.accessibleDescriptionIds[indicator.id]) {
+        this.accessibleDescriptionIds[indicator.id] = uniqueId("oc-indicator-description-")
       }
 
-      return indicator.accessibleDescriptionId
+      return this.accessibleDescriptionIds[indicator.id]
     },
   },
 }

--- a/src/components/resource/OcResource.vue
+++ b/src/components/resource/OcResource.vue
@@ -14,10 +14,19 @@
         :is="componentType"
         v-bind="componentProps"
         v-if="isResourceClickable"
+        :target="linkTargetBlank"
+        :aria-describedby="opensInNewWindowDescriptionId"
         class="oc-text-overflow"
         @click.stop="emitClick"
         @click.native.stop
       >
+        <span
+          v-if="opensInNewWindowDescriptionId"
+          :id="opensInNewWindowDescriptionId"
+          class="oc-invisible-sr"
+          v-text="$gettext('Opens in a new window')"
+        >
+        </span>
         <oc-resource-name
           :key="resource.name"
           :name="resource.name"
@@ -47,6 +56,7 @@ import OcImg from "../OcImage.vue"
 import OcStatusIndicators from "../OcStatusIndicators.vue"
 import OcIcon from "../OcIcon.vue"
 import OcResourceName from "./OcResourceName.vue"
+import uniqueId from "../../utils/uniqueId"
 
 /**
  * Displays a resource together with the resource type icon or preview
@@ -179,6 +189,22 @@ export default {
         to: this.folderLink,
       }
     },
+
+    opensInNewWindowDescriptionId() {
+      if (this.resource.opensInNewWindow) {
+        return uniqueId("oc-link-description-")
+      }
+
+      return null
+    },
+
+    linkTargetBlank() {
+      if (this.isRouterLink && this.resource.opensInNewWindow) {
+        return "_blank"
+      }
+
+      return null
+    },
   },
 
   methods: {
@@ -217,6 +243,7 @@ export default {
 
     a:hover,
     a:focus {
+      outline-offset: 0;
       text-decoration: none;
     }
   }
@@ -266,7 +293,8 @@ export default {
             path: "images/nature/forest-image-with-filename-with-a-lot-of-characters.jpg",
             preview: "https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg",
             indicators: [],
-            type: "file"
+            type: "file",
+            opensInNewWindow: true,
           }
         },
         indicators() {

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -23,7 +23,7 @@
     <template #select="{ item }">
       <oc-checkbox
         :id="`oc-table-files-select-${item.id}`"
-        :label="$gettext('Select')"
+        :label="$gettext('Select resource')"
         :hide-label="true"
         size="large"
         :value="selection"
@@ -122,6 +122,7 @@ export default {
      * - shareDate: The date when the share was created
      * - deletionDate: The date when the resource has been deleted
      * - status: The status of the share. Contains also actions to accept/decline the share
+     * - opensInNewWindow: Open the link in a new window
      */
     resources: {
       type: Array,
@@ -404,7 +405,7 @@ export default {
   <div>
     <oc-table-files :resources="resources" :highlighted="highlighted" disabled="notes" v-model="selected" class="oc-mb" @showDetails="highlightResource" @action="handleAction">
       <template v-slot:quickActions="props">
-        <oc-button @click.stop variation="passive" appearance="raw" aria-label="Share">
+        <oc-button @click.stop variation="passive" appearance="raw" aria-label="Share with other people">
           <oc-icon name="group-add" />
         </oc-button>
         <oc-button @click.stop variation="passive" appearance="raw" aria-label="Create a public link">
@@ -438,6 +439,7 @@ export default {
           type: "file",
           size: "111000234",
           mdate: "Mon, 11 Jan 2021 14:34:04 GMT",
+          opensInNewWindow: true
         },
         {
           id: "notes",
@@ -468,6 +470,7 @@ export default {
           label: "Shared with other people",
           visible: true,
           icon: 'group',
+          accessibleDescription: 'This resource is shared via link',
           handler: (resource, indicatorId) => alert(`Resource: ${resource.name}, indicator: ${indicatorId}`)
         },
         {

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -23,7 +23,7 @@
     <template #select="{ item }">
       <oc-checkbox
         :id="`oc-table-files-select-${item.id}`"
-        :label="$gettext('Select resource')"
+        :label="getResourceCheckboxLabel(item)"
         :hide-label="true"
         size="large"
         :value="selection"
@@ -369,6 +369,14 @@ export default {
       return Array.isArray(this.disabled)
         ? !this.disabled.includes(resourceId)
         : this.disabled !== resourceId
+    },
+
+    getResourceCheckboxLabel(resource) {
+      if (resource.type === "folder") {
+        return this.$gettext("Select folder")
+      }
+
+      return this.$gettext("Select file")
     },
   },
 }

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -35,14 +35,18 @@ exports[`OcTableFiles displays all fields 1`] = `
   </thead>
   <tbody>
     <tr class="oc-tbody-tr oc-tbody-tr-forest" style="height: 64px;">
-      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-forest" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-forest" class="oc-invisible-sr oc-cursor-pointer">Select</label></span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-forest" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-forest" class="oc-invisible-sr oc-cursor-pointer">Select resource</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><img src="https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg" alt="" width="40" height="40" class="oc-resource-preview">
-          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw"><span resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">forest.jpg</span>
+          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw">
+              <!----> <span resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">forest.jpg</span>
               <!----></span>
             </button>
             <div class="oc-resource-indicators">
-              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-1"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-1">Shared via link</title>6:1: text data outside of root node.</svg></span></div>
+              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button>
+                <!----><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-1"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-1">Shared via link</title>6:1: text data outside of root node.</svg></span>
+                <!---->
+              </div>
             </div>
           </div>
         </div>
@@ -80,14 +84,18 @@ exports[`OcTableFiles displays all fields 1`] = `
       </td>
     </tr>
     <tr class="oc-tbody-tr oc-tbody-tr-notes" style="height: 64px;">
-      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-notes" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-notes" class="oc-invisible-sr oc-cursor-pointer">Select</label></span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-notes" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-notes" class="oc-invisible-sr oc-cursor-pointer">Select resource</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span>
-          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw"><span resource-path="/Documents/notes.txt" resource-name="notes.txt" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">notes.txt</span>
+          <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw">
+              <!----> <span resource-path="/Documents/notes.txt" resource-name="notes.txt" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">notes.txt</span>
               <!----></span>
             </button>
             <div class="oc-resource-indicators">
-              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-2"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-2">Shared via link</title>6:1: text data outside of root node.</svg></span></div>
+              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button>
+                <!----><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-2"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-2">Shared via link</title>6:1: text data outside of root node.</svg></span>
+                <!---->
+              </div>
             </div>
           </div>
         </div>
@@ -125,14 +133,18 @@ exports[`OcTableFiles displays all fields 1`] = `
       </td>
     </tr>
     <tr class="oc-tbody-tr oc-tbody-tr-documents" style="height: 64px;">
-      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-documents" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-documents" class="oc-invisible-sr oc-cursor-pointer">Select</label></span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-documents" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-documents" class="oc-invisible-sr oc-cursor-pointer">Select resource</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span>
-          <div class="oc-resource-details oc-text-overflow"><a class="oc-text-overflow"><span resource-path="/Documents" resource-name="Documents" resource-type="folder" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">Documents</span>
+          <div class="oc-resource-details oc-text-overflow"><a class="oc-text-overflow">
+              <!----> <span resource-path="/Documents" resource-name="Documents" resource-type="folder" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">Documents</span>
               <!----></span>
             </a>
             <div class="oc-resource-indicators">
-              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-3"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-3">Shared via link</title>6:1: text data outside of root node.</svg></span></div>
+              <div class="oc-status-indicators"><button aria-label="Shared with other people" class="oc-status-indicators-indicator oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw" id="files-sharing" uk-tooltip="Shared with other people"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span></button>
+                <!----><span class="oc-status-indicators-indicator oc-icon oc-icon-m oc-icon-passive" id="file-link" tabindex="-1" uk-tooltip="Shared via link"><svg aria-labelledby="oc-icon-title-3"><title xmlns="http://www.w3.org/1999/xhtml" id="oc-icon-title-3">Shared via link</title>6:1: text data outside of root node.</svg></span>
+                <!---->
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -35,7 +35,7 @@ exports[`OcTableFiles displays all fields 1`] = `
   </thead>
   <tbody>
     <tr class="oc-tbody-tr oc-tbody-tr-forest" style="height: 64px;">
-      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-forest" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-forest" class="oc-invisible-sr oc-cursor-pointer">Select resource</label></span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-forest" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-forest" class="oc-invisible-sr oc-cursor-pointer">Select file</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><img src="https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg" alt="" width="40" height="40" class="oc-resource-preview">
           <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw">
@@ -84,7 +84,7 @@ exports[`OcTableFiles displays all fields 1`] = `
       </td>
     </tr>
     <tr class="oc-tbody-tr oc-tbody-tr-notes" style="height: 64px;">
-      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-notes" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-notes" class="oc-invisible-sr oc-cursor-pointer">Select resource</label></span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-notes" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-notes" class="oc-invisible-sr oc-cursor-pointer">Select file</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span>
           <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw">
@@ -133,7 +133,7 @@ exports[`OcTableFiles displays all fields 1`] = `
       </td>
     </tr>
     <tr class="oc-tbody-tr oc-tbody-tr-documents" style="height: 64px;">
-      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-documents" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-documents" class="oc-invisible-sr oc-cursor-pointer">Select resource</label></span></td>
+      <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select"><span><input id="oc-table-files-select-documents" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-documents" class="oc-invisible-sr oc-cursor-pointer">Select folder</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false" role="presentation">6:1: text data outside of root node.</svg></span>
           <div class="oc-resource-details oc-text-overflow"><a class="oc-text-overflow">


### PR DESCRIPTION
* Add accessible description in case a resource link opens in a new window
* Add accessible description for status indicators
* Adjust some of the labels to make them more descriptive
* Fix broken outline (focus) on directories

Note that the keyboard navigation for directories in ODS will most likely not work because the `router-link` component fails to transform `to=""` to `href=""`. It's working in Web though.