### PR TITLE
Add modal focus trap

### DIFF
--- a/changelog/unreleased/enhancement-modal-focus-trap
+++ b/changelog/unreleased/enhancement-modal-focus-trap
@@ -1,0 +1,6 @@
+Enhancement: Modal focus trap
+
+We've added [Vue focus trap library](https://github.com/posva/focus-trap-vue) to trap the keyboard navigation inside of the modal.
+To enable the focus trap, use prop `focusTrapActive`.
+
+https://github.com/owncloud/owncloud-design-system/pull/1237

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "eslint-plugin-vue": "^7.2.0",
     "file-loader": "^6.2.0",
     "filesize": "^6.1.0",
+    "focus-trap": "^6.4.0",
+    "focus-trap-vue": "^1.1.1",
     "friendly-errors-webpack-plugin": "^1.7.0",
     "html-loader": "^1.3.2",
     "html-webpack-plugin": "^4.5.0",
@@ -141,6 +143,8 @@
   },
   "peerDependencies": {
     "filesize": "^6.1.0",
+    "focus-trap": "^6.4.0",
+    "focus-trap-vue": "^1.1.1",
     "luxon": "^1.22.0",
     "postcss-import": "^12.0.1",
     "postcss-url": "^9.0.0",

--- a/src/components/OcModal.vue
+++ b/src/components/OcModal.vue
@@ -1,48 +1,50 @@
 <template>
   <div class="oc-modal-background">
-    <div ref="$_ocModal" :class="classes" tabindex="0" role="dialog" aria-modal="true">
-      <div class="oc-modal-title">
-        <oc-icon v-if="icon" :name="icon" :variation="variation" />
-        <h2 v-text="title" />
-      </div>
-      <div class="oc-modal-body">
-        <div v-if="$slots.content" key="modal-slot-content" class="oc-modal-body-message">
-          <slot name="content" />
+    <focus-trap :active="focusTrapActive">
+      <div ref="$_ocModal" :class="classes" tabindex="0" role="dialog" aria-modal="true">
+        <div class="oc-modal-title">
+          <oc-icon v-if="icon" :name="icon" :variation="variation" />
+          <h2 v-text="title" />
         </div>
-        <oc-text-input
-          v-else-if="hasInput"
-          key="modal-input"
-          ref="ocModalInput"
-          v-model="userInputValue"
-          class="oc-modal-body-input"
-          :error-message="inputError"
-          :label="inputLabel"
-          :description-message="inputDescription"
-          :disabled="inputDisabled"
-          :fix-message-line="true"
-          @input="inputOnInput"
-          @keydown.enter="confirm"
-        />
-        <p v-else key="modal-message" class="oc-modal-body-message" v-text="message" />
-        <div class="oc-modal-body-actions uk-flex uk-flex-right">
-          <oc-button
-            class="oc-modal-body-actions-cancel"
-            :variation="buttonCancelVariation"
-            :appearance="buttonCancelAppearance"
-            @click="buttonCancelOnClick"
-            v-text="buttonCancelText"
+        <div class="oc-modal-body">
+          <div v-if="$slots.content" key="modal-slot-content" class="oc-modal-body-message">
+            <slot name="content" />
+          </div>
+          <oc-text-input
+            v-else-if="hasInput"
+            key="modal-input"
+            ref="ocModalInput"
+            v-model="userInputValue"
+            class="oc-modal-body-input"
+            :error-message="inputError"
+            :label="inputLabel"
+            :description-message="inputDescription"
+            :disabled="inputDisabled"
+            :fix-message-line="true"
+            @input="inputOnInput"
+            @keydown.enter="confirm"
           />
-          <oc-button
-            class="oc-modal-body-actions-confirm oc-ml-s"
-            :variation="buttonConfirmVariation || variation"
-            :appearance="buttonConfirmAppearance"
-            :disabled="buttonConfirmDisabled || !!inputError"
-            @click="confirm"
-            v-text="buttonConfirmText"
-          />
+          <p v-else key="modal-message" class="oc-modal-body-message" v-text="message" />
+          <div class="oc-modal-body-actions uk-flex uk-flex-right">
+            <oc-button
+              class="oc-modal-body-actions-cancel"
+              :variation="buttonCancelVariation"
+              :appearance="buttonCancelAppearance"
+              @click="buttonCancelOnClick"
+              v-text="buttonCancelText"
+            />
+            <oc-button
+              class="oc-modal-body-actions-confirm oc-ml-s"
+              :variation="buttonConfirmVariation || variation"
+              :appearance="buttonConfirmAppearance"
+              :disabled="buttonConfirmDisabled || !!inputError"
+              @click="confirm"
+              v-text="buttonConfirmText"
+            />
+          </div>
         </div>
       </div>
-    </div>
+    </focus-trap>
   </div>
 </template>
 
@@ -50,6 +52,7 @@
 import OcButton from "./OcButton.vue"
 import OcIcon from "./OcIcon.vue"
 import OcTextInput from "./OcTextInput.vue"
+import { FocusTrap } from "focus-trap-vue"
 
 /**
  * Modals are generally used to force the user to focus on confirming or completing a single action.
@@ -75,6 +78,7 @@ export default {
     OcButton,
     OcIcon,
     OcTextInput,
+    FocusTrap,
   },
 
   props: {
@@ -226,6 +230,14 @@ export default {
      * Asserts whether the input is disabled or not
      */
     inputDisabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    /**
+     * Asserts whether the modal should be protected with focus trap
+     */
+    focusTrapActive: {
       type: Boolean,
       required: false,
       default: false,
@@ -431,5 +443,34 @@ export default {
       />
     </template>
   </oc-modal>
+```
+
+## Focus trap
+When the modal is displayed, it should not be possible to reach any element outside of the modal. To protect this also for keyboard navigation, focus trap should be activate via prop `focusTrapActive`.
+If activated, only focusable elements within the modal are reachable via keyboard navigation.
+
+```vue
+<template>
+  <div>
+    <oc-button @click="active = !active">Toggle focus trap</oc-button>
+    <p>Focus trap active: {{ active }}</p>
+    <oc-modal
+      icon="info"
+      title="Accept terms of use"
+      message="Do you accept our terms of use?"
+      button-cancel-text="Decline"
+      button-confirm-text="Accept"
+      class="oc-mb-l uk-position-relative"
+      :focus-trap-active="active"
+    />
+  </div>
+</template>
+<script>
+export default {
+  data: () => ({
+    active: false
+  })
+}
+</script>
 ```
 </docs>

--- a/src/components/__snapshots__/OcModal.spec.js.snap
+++ b/src/components/__snapshots__/OcModal.spec.js.snap
@@ -2,74 +2,82 @@
 
 exports[`OcModal displays input 1`] = `
 <div class="oc-modal-background">
-  <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
-    <div class="oc-modal-title">
-      <!---->
-      <h2>Create new folder</h2>
-    </div>
-    <div class="oc-modal-body">
-      <oc-text-input-stub id="oc-textinput-1" type="text" value="New folder" label="Folder name" fixmessageline="true" class="oc-modal-body-input"></oc-text-input-stub>
-      <div class="oc-modal-body-actions uk-flex uk-flex-right">
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+      <div class="oc-modal-title">
+        <!---->
+        <h2>Create new folder</h2>
+      </div>
+      <div class="oc-modal-body">
+        <oc-text-input-stub id="oc-textinput-1" type="text" value="New folder" label="Folder name" fixmessageline="true" class="oc-modal-body-input"></oc-text-input-stub>
+        <div class="oc-modal-body-actions uk-flex uk-flex-right">
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+        </div>
       </div>
     </div>
-  </div>
+  </focus-trap-stub>
 </div>
 `;
 
 exports[`OcModal hides icon if not specified 1`] = `
 <div class="oc-modal-background">
-  <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
-    <div class="oc-modal-title">
-      <!---->
-      <h2>Example title</h2>
-    </div>
-    <div class="oc-modal-body">
-      <p class="oc-modal-body-message">Example message</p>
-      <div class="oc-modal-body-actions uk-flex uk-flex-right">
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+      <div class="oc-modal-title">
+        <!---->
+        <h2>Example title</h2>
+      </div>
+      <div class="oc-modal-body">
+        <p class="oc-modal-body-message">Example message</p>
+        <div class="oc-modal-body-actions uk-flex uk-flex-right">
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+        </div>
       </div>
     </div>
-  </div>
+  </focus-trap-stub>
 </div>
 `;
 
 exports[`OcModal matches snapshot 1`] = `
 <div class="oc-modal-background">
-  <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
-    <div class="oc-modal-title">
-      <oc-icon-stub name="info" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
-      <h2>Example title</h2>
-    </div>
-    <div class="oc-modal-body">
-      <p class="oc-modal-body-message">Example message</p>
-      <div class="oc-modal-body-actions uk-flex uk-flex-right">
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+      <div class="oc-modal-title">
+        <oc-icon-stub name="info" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
+        <h2>Example title</h2>
+      </div>
+      <div class="oc-modal-body">
+        <p class="oc-modal-body-message">Example message</p>
+        <div class="oc-modal-body-actions uk-flex uk-flex-right">
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+        </div>
       </div>
     </div>
-  </div>
+  </focus-trap-stub>
 </div>
 `;
 
 exports[`OcModal overrides props message with slot 1`] = `
 <div class="oc-modal-background">
-  <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
-    <div class="oc-modal-title">
-      <!---->
-      <h2>Example title</h2>
-    </div>
-    <div class="oc-modal-body">
-      <div class="oc-modal-body-message">
-        <p>Slot message</p>
+  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+      <div class="oc-modal-title">
+        <!---->
+        <h2>Example title</h2>
       </div>
-      <div class="oc-modal-body-actions uk-flex uk-flex-right">
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-        <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+      <div class="oc-modal-body">
+        <div class="oc-modal-body-message">
+          <p>Slot message</p>
+        </div>
+        <div class="oc-modal-body-actions uk-flex uk-flex-right">
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+        </div>
       </div>
     </div>
-  </div>
+  </focus-trap-stub>
 </div>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6031,6 +6031,18 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
+focus-trap-vue@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/focus-trap-vue/-/focus-trap-vue-1.1.1.tgz#d29d2de3c64457cc708657682a6670af73982355"
+  integrity sha512-N+M4d4uYymCogct417gUL7wWSMIW/oUcCicfg3eRdo+gz7jlQnIGwUwViFxPkKV7iyzpc81g6JeSxRWiYWU3eQ==
+
+focus-trap@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.4.0.tgz#e9951484fddf933d9b9b0e95b499f9420f6a54d6"
+  integrity sha512-RpH291GjfNhy1ek+Iwe00oCaqJN0sBaB+S/v7BpCIldf39IslPI7657nOZ6HwgoEHpjCmUJoAY+Mfgrm0rohvQ==
+  dependencies:
+    tabbable "^5.2.0"
+
 follow-redirects@^1.0.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
@@ -13302,6 +13314,11 @@ symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+tabbable@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.0.tgz#4fba60991d8bb89d06e5d9455c92b453acf88fb2"
+  integrity sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg==
 
 table@^6.0.4, table@^6.0.7:
   version "6.0.7"


### PR DESCRIPTION
We've added [Vue focus trap library](https://github.com/posva/focus-trap-vue) to trap the keyboard navigation inside of the modal.
To enable the focus trap, use prop `focusTrapActive`.