### PR TITLE
Aria-hide images without alt tags

### DIFF
--- a/changelog/unreleased/enhancement-aria-hide-images
+++ b/changelog/unreleased/enhancement-aria-hide-images
@@ -1,0 +1,5 @@
+Enhancement: Aria-hide images if needed
+
+When the `alt` property of the oc-image is empty we now set `aria-hidden="true"`.
+
+https://github.com/owncloud/owncloud-design-system/pull/1244

--- a/src/components/OcImage.vue
+++ b/src/components/OcImage.vue
@@ -1,5 +1,5 @@
 <template>
-  <img :src="src" :alt="alt" :title="title" />
+  <img :src="src" :alt="alt" :aria-hidden="ariaHidden" :title="title" />
 </template>
 <script>
 /**
@@ -35,6 +35,11 @@ export default {
       type: String,
       required: false,
       default: null,
+    },
+  },
+  computed: {
+    ariaHidden() {
+      return this.alt.length === 0
     },
   },
 }

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -37,7 +37,7 @@ exports[`OcTableFiles displays all fields 1`] = `
     <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-forest" style="height: 64px;">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select oc-pl-s "><span><input id="oc-table-files-select-forest" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-forest" class="oc-invisible-sr oc-cursor-pointer">Select file</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
-        <div class="oc-resource oc-text-overflow"><img src="https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg" alt="" width="40" height="40" class="oc-resource-preview">
+        <div class="oc-resource oc-text-overflow"><img src="https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg" alt="" aria-hidden="true" width="40" height="40" class="oc-resource-preview">
           <div class="oc-resource-details oc-text-overflow"><button class="oc-text-overflow oc-button oc-button-m oc-button-justify-content-center oc-button-gap-undefined oc-button-passive oc-button-passive-raw">
               <!----> <span resource-path="images/nature/forest.jpg" resource-name="forest.jpg" resource-type="file" class="oc-resource-name oc-text-truncate"><!----><span class="oc-resource-basename">forest.jpg</span>
               <!----></span>


### PR DESCRIPTION
When the `alt` property of the oc-image is empty we now set `aria-hidden="true"`.