### PR TITLE
Remove close button on notifications

### DIFF
--- a/changelog/unreleased/enhancement-remove-notification-close-button
+++ b/changelog/unreleased/enhancement-remove-notification-close-button
@@ -1,0 +1,6 @@
+Enhancement: Remove the notification close button
+
+The notification will now automatically close after a certain amount of time which can be defined via property.
+Also fixed some links in the docs in addition to that.
+
+https://github.com/owncloud/owncloud-design-system/pull/1247

--- a/changelog/unreleased/enhancement-remove-notification-close-button
+++ b/changelog/unreleased/enhancement-remove-notification-close-button
@@ -1,7 +1,0 @@
-Enhancement: Remove the notification close button
-
-Instead of closing a notification via button, it will now automatically close after a certain amount of time.
-The duration a notification shows can be defined via a newly added property. Also fixed some links in the docs
-in addition to that.
-
-https://github.com/owncloud/owncloud-design-system/pull/1247

--- a/changelog/unreleased/enhancement-remove-notification-close-button
+++ b/changelog/unreleased/enhancement-remove-notification-close-button
@@ -1,0 +1,7 @@
+Enhancement: Remove the notification close button
+
+Instead of closing a notification via button, it will now automatically close after a certain amount of time.
+The duration a notification shows can be defined via a newly added property. Also fixed some links in the docs
+in addition to that.
+
+https://github.com/owncloud/owncloud-design-system/pull/1247

--- a/changelog/unreleased/enhancement-show-notification-close-button-via-property
+++ b/changelog/unreleased/enhancement-show-notification-close-button-via-property
@@ -1,0 +1,8 @@
+Enhancement: Show the notification close button via property
+
+Close button can now be enabled via property dismissible,
+additionally the notification will now automatically close after a certain amount of time.
+The duration a notification shows can be defined via a newly added property. Also fixed some links in the docs
+in addition to that.
+
+https://github.com/owncloud/owncloud-design-system/pull/1247

--- a/changelog/unreleased/enhancement-show-notification-close-button-via-property
+++ b/changelog/unreleased/enhancement-show-notification-close-button-via-property
@@ -1,7 +1,0 @@
-Enhancement: Show the notification close button via property
-
-The close-button can now be enabled via the property "dismissible". Additionally the notification will
-automatically close after a certain amount of time, which also can be defined via property. When a notification is
-dismissible, the timeout can be bypassed with the value 0. Also fixed some links in the docs in addition to that.
-
-https://github.com/owncloud/owncloud-design-system/pull/1247

--- a/changelog/unreleased/enhancement-show-notification-close-button-via-property
+++ b/changelog/unreleased/enhancement-show-notification-close-button-via-property
@@ -1,8 +1,7 @@
 Enhancement: Show the notification close button via property
 
-Close button can now be enabled via property dismissible,
-additionally the notification will now automatically close after a certain amount of time.
-The duration a notification shows can be defined via a newly added property. Also fixed some links in the docs
-in addition to that.
+The close-button can now be enabled via the property "dismissible". Additionally the notification will
+automatically close after a certain amount of time, which also can be defined via property. When a notification is
+dismissible, the timeout can be bypassed with the value 0. Also fixed some links in the docs in addition to that.
 
 https://github.com/owncloud/owncloud-design-system/pull/1247

--- a/src/components/OCNotificationMessage.vue
+++ b/src/components/OCNotificationMessage.vue
@@ -90,8 +90,15 @@ export default {
     },
   },
   mounted() {
+    /**
+     * Notification will be destroyed if timeout is set
+     */
+    if (!this.timeout && this.dismissible) {
+      return
+    }
+
     setTimeout(() => {
-      this.$emit("close")
+      this.close()
     }, this.timeout * 1000)
   },
   methods: {

--- a/src/components/OCNotificationMessage.vue
+++ b/src/components/OCNotificationMessage.vue
@@ -13,17 +13,6 @@
         {{ message }}
       </div>
     </div>
-    <oc-button
-      v-if="dismissible"
-      name="close"
-      appearance="raw"
-      :variation="iconVariation"
-      :aria-label="$gettext('Close notification')"
-      class="uk-position-top-right oc-mt-s oc-mr-s"
-      @click="close"
-    >
-      <oc-icon name="close" :variation="iconVariation" />
-    </oc-button>
   </div>
 </template>
 <script>
@@ -65,21 +54,12 @@ export default {
       default: null,
     },
     /**
-     * Number of seconds the message shows. It will disappear after this time. Setting the timeout to 0 while the
-     * notification is dismissible will bypass the timeout.
+     * Number of seconds the message shows. It will disappear after this time.
      */
     timeout: {
       type: Number,
       required: false,
       default: 5,
-    },
-    /**
-     * Property weather a close button will be shown or not
-     */
-    dismissible: {
-      type: Boolean,
-      required: false,
-      default: false,
     },
   },
   computed: {
@@ -94,10 +74,6 @@ export default {
     /**
      * Notification will be destroyed if timeout is set
      */
-    if (!this.timeout && this.dismissible) {
-      return
-    }
-
     setTimeout(() => {
       this.close()
     }, this.timeout * 1000)

--- a/src/components/OCNotificationMessage.vue
+++ b/src/components/OCNotificationMessage.vue
@@ -60,6 +60,7 @@ export default {
       type: Number,
       required: false,
       default: 5,
+      validator: value => value > 0,
     },
   },
   computed: {

--- a/src/components/OCNotificationMessage.vue
+++ b/src/components/OCNotificationMessage.vue
@@ -65,7 +65,8 @@ export default {
       default: null,
     },
     /**
-     * Number of seconds the message shows. It will disappear after this time.
+     * Number of seconds the message shows. It will disappear after this time. Setting the timeout to 0 while the
+     * notification is dismissible will bypass the timeout.
      */
     timeout: {
       type: Number,

--- a/src/components/OCNotificationMessage.vue
+++ b/src/components/OCNotificationMessage.vue
@@ -13,6 +13,17 @@
         {{ message }}
       </div>
     </div>
+    <oc-button
+      v-if="dismissible"
+      name="close"
+      appearance="raw"
+      :variation="iconVariation"
+      :aria-label="$gettext('Close notification')"
+      class="uk-position-top-right oc-mt-s oc-mr-s"
+      @click="close"
+    >
+      <oc-icon name="close" :variation="iconVariation" />
+    </oc-button>
   </div>
 </template>
 <script>
@@ -61,6 +72,14 @@ export default {
       required: false,
       default: 5,
     },
+    /**
+     * Property weather a close button will be shown or not
+     */
+    dismissible: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
   computed: {
     classes() {
@@ -74,6 +93,15 @@ export default {
     setTimeout(() => {
       this.$emit("close")
     }, this.timeout * 1000)
+  },
+  methods: {
+    close() {
+      /**
+       * The close event is emitted when the user clicks the close icon.
+       * @type {void}
+       */
+      this.$emit("close")
+    },
   },
 }
 </script>

--- a/src/components/OCNotificationMessage.vue
+++ b/src/components/OCNotificationMessage.vue
@@ -1,11 +1,6 @@
 <template>
-  <div class="oc-alert" :class="$_ocNotificationMessage_classes">
-    <oc-icon
-      :variation="$_ocNotificationMessage_iconVariation"
-      size="large"
-      name="info"
-      class="oc-mr-s"
-    />
+  <div class="oc-alert" :class="classes">
+    <oc-icon :variation="iconVariation" size="large" name="info" class="oc-mr-s" />
     <div
       class="uk-flex uk-flex-wrap uk-flex-middle uk-flex-1 oc-mr"
       :role="status === 'danger' ? 'alert' : 'status'"
@@ -18,16 +13,6 @@
         {{ message }}
       </div>
     </div>
-    <oc-button
-      name="close"
-      appearance="raw"
-      :variation="$_ocNotificationMessage_iconVariation"
-      :aria-label="$gettext('Close notification')"
-      class="uk-position-top-right oc-mt-s oc-mr-s"
-      @click="$_ocNotificationMessage_close"
-    >
-      <oc-icon name="close" :variation="$_ocNotificationMessage_iconVariation" />
-    </oc-button>
   </div>
 </template>
 <script>
@@ -68,23 +53,27 @@ export default {
       required: false,
       default: null,
     },
+    /**
+     * Number of seconds the message shows. It will disappear after this time.
+     */
+    timeout: {
+      type: Number,
+      required: false,
+      default: 5,
+    },
   },
   computed: {
-    $_ocNotificationMessage_classes() {
+    classes() {
       return `uk-flex uk-flex-wrap uk-notification-message uk-notification-message-${this.status}`
     },
-    $_ocNotificationMessage_iconVariation() {
+    iconVariation() {
       return this.status
     },
   },
-  methods: {
-    $_ocNotificationMessage_close() {
-      /**
-       * The close event is emitted when the user clicks the close icon.
-       * @type {void}
-       */
+  mounted() {
+    setTimeout(() => {
       this.$emit("close")
-    },
+    }, this.timeout * 1000)
   },
 }
 </script>
@@ -111,5 +100,5 @@ export default {
 </style>
 
 <docs>
-  Please have a look at the component [oc-notifications](#/oC%20Components/oc-notifications) for example code.
+  Please have a look at the component [OcNotifications](#/oC%20Components/OcNotifications) for example code.
 </docs>

--- a/src/components/OCNotifications.vue
+++ b/src/components/OCNotifications.vue
@@ -60,7 +60,6 @@ export default {
                   :status="item.status"
                   :title="item.title"
                   :message="item.message"
-                  :timeout="item.timeout"
                   @close="removeNotification('center', item)"
               />
             </transition-group>
@@ -75,7 +74,6 @@ export default {
                 :status="item.status"
                 :title="item.title"
                 :message="item.message"
-                :timeout="item.timeout"
                 @close="removeNotification('right', item)"
             />
           </oc-notifications>

--- a/src/components/OCNotifications.vue
+++ b/src/components/OCNotifications.vue
@@ -71,7 +71,7 @@ export default {
           <oc-notifications position="top-right">
             <oc-notification-message
                 v-for="(item, index) in messages.right"
-                :key="index"
+                :key="item.title"
                 :status="item.status"
                 :title="item.title"
                 :message="item.message"

--- a/src/components/OCNotifications.vue
+++ b/src/components/OCNotifications.vue
@@ -61,6 +61,7 @@ export default {
                   :title="item.title"
                   :message="item.message"
                   :dismissible="item.dismissible"
+                  :timeout="item.timeout"
                   @close="removeNotification('center', item)"
               />
             </transition-group>
@@ -76,6 +77,7 @@ export default {
                 :title="item.title"
                 :message="item.message"
                 :dismissible="item.dismissible"
+                :timeout="item.timeout"
                 @close="removeNotification('right', item)"
             />
           </oc-notifications>
@@ -108,6 +110,12 @@ export default {
               title: 'This is a dismissible notification',
               status: 'passive',
               dismissible: true,
+            },
+            {
+              title: 'This is a dismissible notification which will not automatically disappear',
+              status: 'passive',
+              dismissible: true,
+              timeout: 0,
             },
             {
               title: 'This is a primary notification with a long title that spans more than just one line',

--- a/src/components/OCNotifications.vue
+++ b/src/components/OCNotifications.vue
@@ -60,7 +60,6 @@ export default {
                   :status="item.status"
                   :title="item.title"
                   :message="item.message"
-                  :dismissible="item.dismissible"
                   :timeout="item.timeout"
                   @close="removeNotification('center', item)"
               />
@@ -76,7 +75,6 @@ export default {
                 :status="item.status"
                 :title="item.title"
                 :message="item.message"
-                :dismissible="item.dismissible"
                 :timeout="item.timeout"
                 @close="removeNotification('right', item)"
             />
@@ -105,17 +103,6 @@ export default {
             {
               title: 'Default without a message',
               status: 'passive'
-            },
-            {
-              title: 'This is a dismissible notification',
-              status: 'passive',
-              dismissible: true,
-            },
-            {
-              title: 'This is a dismissible notification which will not automatically disappear',
-              status: 'passive',
-              dismissible: true,
-              timeout: 0,
             },
             {
               title: 'This is a primary notification with a long title that spans more than just one line',

--- a/src/components/OCNotifications.vue
+++ b/src/components/OCNotifications.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="oc-alerts" :class="$_ocNotifications_classes">
+  <div class="oc-alerts" :class="classes">
     <slot></slot>
   </div>
 </template>
 
 <script>
 /**
- * Notifications are used to inform users about errors, warnings and as confirmations for their actions.
+ * Notifications are used to inform users about errors, warnings and as confirmations for their actions. They will automatically disappear after a certain amount of time.
  *
- * The default slot can be filled with [oc-notification-message](#/oC%20Components/oc-notification-message) elements.
+ * The default slot can be filled with [OcNotificationMessage](#/oC%20Components/OcNotificationMessage) elements.
  *
  * ## Accessibility
  *
@@ -34,7 +34,7 @@ export default {
     },
   },
   computed: {
-    $_ocNotifications_classes() {
+    classes() {
       return `uk-notification uk-notification-${this.position}`
     },
   },
@@ -60,6 +60,7 @@ export default {
                   :status="item.status"
                   :title="item.title"
                   :message="item.message"
+                  :timeout="item.timeout"
                   @close="removeNotification('center', item)"
               />
             </transition-group>
@@ -74,6 +75,7 @@ export default {
                 :status="item.status"
                 :title="item.title"
                 :message="item.message"
+                :timeout="item.timeout"
                 @close="removeNotification('right', item)"
             />
           </oc-notifications>

--- a/src/components/OCNotifications.vue
+++ b/src/components/OCNotifications.vue
@@ -60,6 +60,7 @@ export default {
                   :status="item.status"
                   :title="item.title"
                   :message="item.message"
+                  :dismissible="item.dismissible"
                   @close="removeNotification('center', item)"
               />
             </transition-group>
@@ -74,6 +75,7 @@ export default {
                 :status="item.status"
                 :title="item.title"
                 :message="item.message"
+                :dismissible="item.dismissible"
                 @close="removeNotification('right', item)"
             />
           </oc-notifications>
@@ -101,6 +103,11 @@ export default {
             {
               title: 'Default without a message',
               status: 'passive'
+            },
+            {
+              title: 'This is a dismissible notification',
+              status: 'passive',
+              dismissible: true,
             },
             {
               title: 'This is a primary notification with a long title that spans more than just one line',


### PR DESCRIPTION
Notifications will now automatically close after a certain amount of time which can be defined via property. Also fixed some links in the docs in addition to that.

Small improvements in the course of this:

* fixed some links in the docs
* removed prefixes from properties