### PR TITLE
Added l10n no options text, added translation for vue-select combobox aria-label

### DIFF
--- a/changelog/unreleased/enhancement-oc-select-a11y 
+++ b/changelog/unreleased/enhancement-oc-select-a11y 
@@ -1,0 +1,6 @@
+Enhancement: Accessibility for OcSelect
+
+- Add l10n for default no options text
+- Add l10n for vue-select combobox aria-label
+
+https://github.com/owncloud/owncloud-design-system/pull/1268

--- a/src/components/OcSelect.vue
+++ b/src/components/OcSelect.vue
@@ -3,7 +3,7 @@
     <template v-for="(index, name) in $scopedSlots" #[name]="data">
       <slot :name="name" v-bind="data"></slot>
     </template>
-    <template slot="no-options" v-translate>No options available.</template>
+    <div slot="no-options" v-translate>No options available.</div>
   </vue-select>
 </template>
 
@@ -159,9 +159,6 @@ We can then retrieve all the values that we want to display from the slots param
           <strong v-text="title" />
         </span>
         <span class="option" v-text="desc" />
-      </template>
-      <template #no-options>
-        Your search query haven't returned any results.
       </template>
     </oc-select>
     <p>

--- a/src/components/OcSelect.vue
+++ b/src/components/OcSelect.vue
@@ -3,7 +3,7 @@
     <template v-for="(index, name) in $scopedSlots" #[name]="data">
       <slot :name="name" v-bind="data"></slot>
     </template>
-    <div slot="no-options" v-translate>No options available.</div>
+    <template #no-options v-translate>No options available.</template>
   </vue-select>
 </template>
 
@@ -155,6 +155,9 @@ We can then retrieve all the values that we want to display from the slots param
   <div class="uk-width-medium">
     <oc-select v-model="selected" :options="options" label="title" class="oc-mb-m">
       <template v-slot:option="{ title, desc }">
+        <template #no-options>
+         Your search query haven't returned any results.
+        </template>
         <span class="option">
           <strong v-text="title" />
         </span>

--- a/src/components/OcSelect.vue
+++ b/src/components/OcSelect.vue
@@ -3,7 +3,7 @@
     <template v-for="(index, name) in $scopedSlots" #[name]="data">
       <slot :name="name" v-bind="data"></slot>
     </template>
-    <template #no-options v-translate>No options available.</template>
+    <div slot="no-options" v-translate>No options available.</div>
   </vue-select>
 </template>
 
@@ -155,13 +155,13 @@ We can then retrieve all the values that we want to display from the slots param
   <div class="uk-width-medium">
     <oc-select v-model="selected" :options="options" label="title" class="oc-mb-m">
       <template v-slot:option="{ title, desc }">
-        <template #no-options>
-         Your search query haven't returned any results.
-        </template>
         <span class="option">
           <strong v-text="title" />
         </span>
         <span class="option" v-text="desc" />
+      </template>
+      <template #no-options>
+        Your search query haven't returned any results.
       </template>
     </oc-select>
     <p>

--- a/src/components/OcSelect.vue
+++ b/src/components/OcSelect.vue
@@ -1,8 +1,9 @@
 <template>
-  <vue-select :value="model" class="oc-select" v-bind="$attrs" v-on="$listeners">
+  <vue-select ref="select" :value="model" class="oc-select" v-bind="$attrs" v-on="$listeners">
     <template v-for="(index, name) in $scopedSlots" #[name]="data">
       <slot :name="name" v-bind="data"></slot>
     </template>
+    <div slot="no-options" v-translate>No options available.</div>
   </vue-select>
 </template>
 
@@ -30,6 +31,16 @@ export default {
       type: [Array, String, Object],
       required: false,
       default: null,
+    },
+  },
+
+  mounted() {
+    this.setComboBoxAriaLabel()
+  },
+  methods: {
+    setComboBoxAriaLabel() {
+      const comboBoxElement = this.$refs.select.$el.querySelector("div:first-child")
+      comboBoxElement.setAttribute("aria-label", this.$gettext("Search for option"))
     },
   },
 }
@@ -148,9 +159,6 @@ We can then retrieve all the values that we want to display from the slots param
           <strong v-text="title" />
         </span>
         <span class="option" v-text="desc" />
-      </template>
-      <template #no-options>
-        Your search query haven't returned any results.
       </template>
     </oc-select>
     <p>

--- a/src/components/OcSelect.vue
+++ b/src/components/OcSelect.vue
@@ -3,7 +3,7 @@
     <template v-for="(index, name) in $scopedSlots" #[name]="data">
       <slot :name="name" v-bind="data"></slot>
     </template>
-    <template #no-options v-translate>No options available.</template>
+    <template slot="no-options" v-translate>No options available.</template>
   </vue-select>
 </template>
 
@@ -155,13 +155,13 @@ We can then retrieve all the values that we want to display from the slots param
   <div class="uk-width-medium">
     <oc-select v-model="selected" :options="options" label="title" class="oc-mb-m">
       <template v-slot:option="{ title, desc }">
-        <template #no-options>
-         Your search query haven't returned any results.
-        </template>
         <span class="option">
           <strong v-text="title" />
         </span>
         <span class="option" v-text="desc" />
+      </template>
+      <template #no-options>
+        Your search query haven't returned any results.
       </template>
     </oc-select>
     <p>


### PR DESCRIPTION
This PR addresses to issues:

1. Adding a default No options available slot, which appears if there are no items passed to the component or the while type in a search query without a result. This text will also be synced to transifex.

2. Unfortunately there is an aria label in the combo box with the text: "Search for option" which can't be replaced via the vue-select API, in order to sync the text to transifex we need to replace it. 
![Screenshot from 2021-05-03 11-48-15](https://user-images.githubusercontent.com/26169327/116862817-9c2de700-ac05-11eb-8d57-3ba83473687a.png)
