### PR TITLE
replace uk-drop by using tippy

### DIFF
--- a/changelog/unreleased/enhancement-oc-drop
+++ b/changelog/unreleased/enhancement-oc-drop
@@ -1,0 +1,6 @@
+Enhancement: Remove uk-drop from OcDrop
+
+We've used uikit to manage oc-drop before, now tippy.js acts as a drop in replacement.
+The api stays the same.
+
+https://github.com/owncloud/owncloud-design-system/pull/1269

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
     "@babel/register": "^7.8.3",
-    "@vue/test-utils": "^1.0.0-beta.31",
+    "@vue/test-utils": "^1.2.0",
     "autoprefixer": "^9.7.4",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.2",

--- a/src/components/OcDrop.spec.js
+++ b/src/components/OcDrop.spec.js
@@ -92,29 +92,30 @@ describe("OcDrop", () => {
 
   it("renders tippy", async () => {
     const { wrapper } = dom()
+    const trigger = wrapper.find("#trigger")
     const wait = async () => {
       await wrapper.vm.$nextTick()
       return new Promise(resolve => setTimeout(resolve, 100))
     }
 
-    await wrapper.find("#trigger").trigger("click") // show
+    await trigger.trigger("click") // show
     await wait()
     expect(wrapper.findComponent(Drop).exists()).toBeTruthy()
-    expect(wrapper.find("#trigger").attributes()["aria-expanded"]).toBe("true")
+    expect(trigger.attributes()["aria-expanded"]).toBe("true")
     expect(wrapper.element).toMatchSnapshot()
 
-    await wrapper.find("#trigger").trigger("click") // hide
+    await trigger.trigger("click") // hide
     await wait()
-    expect(wrapper.find("#trigger").attributes()["aria-expanded"]).toBe("false")
+    expect(trigger.attributes()["aria-expanded"]).toBe("false")
     expect(wrapper.element).toMatchSnapshot()
 
     await wrapper.setData({
       mode: "hover",
     })
 
-    await wrapper.find("#trigger").trigger("mouseenter") // show
+    await trigger.trigger("mouseenter") // show
     await wait()
-    expect(wrapper.find("#trigger").attributes()["aria-expanded"]).toBe("true")
+    expect(trigger.attributes()["aria-expanded"]).toBe("true")
     expect(wrapper.element).toMatchSnapshot()
   })
 })

--- a/src/components/OcDrop.spec.js
+++ b/src/components/OcDrop.spec.js
@@ -1,0 +1,120 @@
+import { shallowMount, mount } from "@vue/test-utils"
+import Drop from "./OcDrop.vue"
+
+const dom = ({ position = "auto", mode = "click" } = {}) => {
+  document.body.innerHTML = ""
+  const wrapper = mount(
+    {
+      template:
+        '<div><p id="trigger">trigger</p><oc-drop :position="position" :mode="mode" toggle="#trigger">show</oc-drop></div>',
+      components: { "oc-drop": Drop },
+    },
+    {
+      attachTo: document.body,
+      data: () => ({ position, mode }),
+    }
+  )
+  const drop = wrapper.findComponent({ name: "oc-drop" })
+  const tippy = drop.vm.$data.tippy
+
+  return { wrapper, drop, tippy }
+}
+
+describe("OcDrop", () => {
+  it("handles dropId prop", () => {
+    for (let i = 0; i < 5; i++) {
+      const wrapper = shallowMount(Drop)
+      expect(wrapper.attributes().id).toBe(`oc-drop-${i + 1}`)
+    }
+
+    for (let i = 0; i < 5; i++) {
+      const id = `custom-drop-id-${i}`
+      const wrapper = shallowMount(Drop, {
+        propsData: {
+          dropId: id,
+        },
+      })
+      expect(wrapper.attributes().id).toBe(id)
+    }
+  })
+
+  it("handles position prop", () => {
+    ;[
+      "top",
+      "right",
+      "bottom",
+      "left",
+      "auto",
+      "top-start",
+      "top-end",
+      "right-start",
+      "right-end",
+      "bottom-start",
+      "bottom-end",
+      "left-start",
+      "left-end",
+      "auto-start",
+      "auto-end",
+    ].forEach(pos => {
+      expect(Drop.props.position.validator(pos)).toBeTruthy()
+    })
+
+    expect(Drop.props.position.validator("unknown")).toBeFalsy()
+  })
+
+  it("handles mode prop", () => {
+    ;["click", "hover"].forEach(pos => {
+      expect(Drop.props.mode.validator(pos)).toBeTruthy()
+    })
+
+    expect(Drop.props.mode.validator("unknown")).toBeFalsy()
+  })
+
+  it("inits tippy", async () => {
+    const { wrapper, drop, tippy } = dom()
+
+    expect(tippy).toBeTruthy()
+    expect(tippy.reference).toBe(wrapper.find("#trigger").element)
+    expect(tippy.props.content).toBe(drop.vm.$refs.drop)
+  })
+
+  it("updates tippy", async () => {
+    const { wrapper, tippy } = dom()
+
+    await wrapper.setData({
+      position: "left",
+      mode: "hover",
+    })
+
+    expect(tippy.props.placement).toBe("left")
+    expect(tippy.props.trigger).toBe("mouseenter focus")
+  })
+
+  it("renders tippy", async () => {
+    const { wrapper } = dom()
+    const wait = async () => {
+      await wrapper.vm.$nextTick()
+      return new Promise(resolve => setTimeout(resolve, 100))
+    }
+
+    await wrapper.find("#trigger").trigger("click") // show
+    await wait()
+    expect(wrapper.findComponent(Drop).exists()).toBeTruthy()
+    expect(wrapper.find("#trigger").attributes()["aria-expanded"]).toBe("true")
+    expect(wrapper.element).toMatchSnapshot()
+
+    await wrapper.find("#trigger").trigger("click") // hide
+    await wait()
+    expect(wrapper.find("#trigger").attributes()["aria-expanded"]).toBe("false")
+    expect(wrapper.element).toMatchSnapshot()
+
+    await wrapper.setData({
+      mode: "hover",
+    })
+
+    await wrapper.find("#trigger").trigger("mouseenter") // show
+    await wait()
+    expect(wrapper.find("#trigger").attributes()["aria-expanded"]).toBe("true")
+    expect(wrapper.element).toMatchSnapshot()
+  })
+})

--- a/src/components/OcDrop.vue
+++ b/src/components/OcDrop.vue
@@ -106,6 +106,9 @@ export default {
       interactive: true,
       plugins: [hideOnEsc],
       theme: "none",
+      aria: {
+        content: "describedby",
+      },
       onShow(instance) {
         hideAll({ exclude: instance })
       },

--- a/src/components/OcDrop.vue
+++ b/src/components/OcDrop.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :id="dropId" class="oc-drop" :uk-drop="$_ocDrop_props" @click="$_ocDrop_close">
+  <div :id="dropId" ref="drop" class="oc-drop" @click="$_ocDrop_close">
     <div v-if="$slots.default" class="uk-card uk-card-default uk-card-small uk-card-body">
       <slot />
     </div>
@@ -7,7 +7,9 @@
   </div>
 </template>
 <script>
-import UiKit from "uikit"
+import tippy, { hideAll } from "tippy.js"
+
+import { destroy, hideOnEsc } from "../directives/OcTooltip"
 import uniqueId from "../utils/uniqueId"
 
 /**
@@ -27,28 +29,21 @@ export default {
       default: () => uniqueId("oc-drop-"),
     },
     /**
-     * CSS selector of the element to maintain the drop's visibility. see https://getuikit.com/docs/drop#boundary
-     **/
-    boundary: {
-      type: [String, Boolean],
-      default: false,
-    },
-    /**
      * CSS selector for the element to be used as toggle. By default, the preceding element is used.
      **/
     toggle: {
       type: String,
-      default: "- *",
+      default: "",
     },
     /**
-     * The position of the drop.
+     * The position of the drop: `(top|right|bottom|left|auto)|(top|right|bottom|left|auto)-(start|end)`.
      **/
     position: {
       type: String,
-      default: "bottom-left",
+      default: "bottom-start",
       validator: value => {
         return value.match(
-          /((top|bottom)-(left|center|right|justify)|(left|right)-(top|center|bottom))/
+          /((top|right|bottom|left|auto)|(top|right|bottom|left|auto)-(start|end))/
         )
       },
     },
@@ -69,43 +64,77 @@ export default {
       type: Boolean,
       required: false,
     },
-    /**
-     * More options are available - see https://getuikit.com/docs/drop
-     **/
-    options: {
-      type: Object,
-      default() {
-        return {
-          "boundary-align": true,
-        }
-      },
-    },
+  },
+  data() {
+    return { tippy: null }
   },
   computed: {
-    $_ocDrop_props() {
-      // from properties
-      let boundary = this.boundary || this.toggle
-      let toggle = this.toggle
-      let mode = this.mode
-      let pos = this.position
-
-      // Collected properties
-      let props = Object.assign({ boundary, toggle, mode, pos }, this.options)
-
-      return JSON.stringify(props)
+    triggerMapping() {
+      return (
+        {
+          hover: "mouseenter focus",
+        }[this.mode] || this.mode
+      )
     },
+  },
+  watch: {
+    position() {
+      this.tippy.setProps({ placement: this.position })
+    },
+
+    mode() {
+      this.tippy.setProps({ trigger: this.triggerMapping })
+    },
+  },
+  beforeDestroy() {
+    destroy(this.tippy)
+  },
+  mounted() {
+    destroy(this.tippy)
+    const to = this.toggle ? document.querySelector(this.toggle) : this.$el.previousElementSibling
+    const content = this.$refs.drop
+
+    if (!to || !content) {
+      return
+    }
+
+    this.tippy = tippy(to, {
+      trigger: this.triggerMapping,
+      placement: this.position,
+      arrow: false,
+      hideOnClick: true,
+      interactive: true,
+      plugins: [hideOnEsc],
+      theme: "none",
+      onShow(instance) {
+        hideAll({ exclude: instance })
+      },
+      content,
+    })
   },
   methods: {
     $_ocDrop_close() {
       if (this.closeOnClick) {
-        UiKit.drop(`#${this.dropId}`).hide()
+        this.tippy.hide()
       }
     },
   },
 }
 </script>
 <style lang="scss">
+.tippy-box[data-theme~="none"] {
+  background-color: transparent;
+  font-size: inherit;
+  line-height: inherit;
+
+  .tippy-content {
+    padding: 0;
+  }
+}
+
 .oc-drop {
+  width: 300px;
+
   li a:focus {
     outline: auto 1px !important;
   }
@@ -113,7 +142,7 @@ export default {
 </style>
 <docs>
 ```jsx
-<div>
+<template>
   <div class="uk-button-group oc-mt-s">
     <oc-button id="my_menu" class="oc-mr-s">Menu</oc-button>
     <oc-drop toggle="#my_menu" mode="click">
@@ -131,19 +160,21 @@ export default {
       </p>
       <ul class="uk-list">
         <li>
-          <oc-checkbox /> <span class="oc-text-muted">Show Files</span>
+          <oc-checkbox label="" />
+          <span class="oc-text-muted">Show Files</span>
         </li>
         <li>
-          <oc-checkbox /> <span class="oc-text-muted">Show Folders</span>
+          <oc-checkbox label="" />
+          <span class="oc-text-muted">Show Folders</span>
         </li>
         <li>
-          <oc-search-bar small placeholder="Filter by name" :button="false" />
+          <oc-search-bar small placeholder="Filter by name" :button="false" label="" />
         </li>
       </ul>
     </oc-drop>
 
     <oc-button id="my_advanced">Advanced</oc-button>
-    <oc-drop dropId="oc-drop" toggle="#my_advanced" mode="click" closeOnClick :options="{ 'delay-hide': '0' }">
+    <oc-drop dropId="oc-drop" toggle="#my_advanced" mode="click" closeOnClick>
       <div slot="special" class="uk-card uk-card-default">
         <div class="uk-card-header">
           <h3 class="uk-card-title">
@@ -158,6 +189,6 @@ export default {
       </div>
     </oc-drop>
   </div>
-</div>
+</template>
 ```
 </docs>

--- a/src/components/__snapshots__/OcBreadcrumb.spec.js.snap
+++ b/src/components/__snapshots__/OcBreadcrumb.spec.js.snap
@@ -19,7 +19,7 @@ exports[`OcBreadcrumb displays all items 1`] = `
   <div class="oc-breadcrumb-drop"><label tabindex="0" class="oc-breadcrumb-drop-label"><span aria-current="page" class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
       <oc-icon-stub name="expand_more" accessiblelabel="Expand more" type="span" size="medium" variation="passive" class="oc-breadcrumb-drop-label-icon"></oc-icon-stub>
     </label>
-    <oc-drop-stub dropid="oc-drop-2" toggle="- *" position="bottom-left" mode="click" options="[object Object]">
+    <oc-drop-stub dropid="oc-drop-2" toggle="" position="bottom-start" mode="click" options="[object Object]">
       <ol class="uk-nav uk-nav-default">
         <li>
           <router-link-stub tag="a" to="[object Object]">Deep</router-link-stub>
@@ -55,7 +55,7 @@ exports[`OcBreadcrumb sets correct variation 1`] = `
   <div class="oc-breadcrumb-drop"><label tabindex="0" class="oc-breadcrumb-drop-label"><span aria-current="page" class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
       <oc-icon-stub name="expand_more" accessiblelabel="Expand more" type="span" size="medium" variation="passive" class="oc-breadcrumb-drop-label-icon"></oc-icon-stub>
     </label>
-    <oc-drop-stub dropid="oc-drop-1" toggle="- *" position="bottom-left" mode="click" options="[object Object]">
+    <oc-drop-stub dropid="oc-drop-1" toggle="" position="bottom-start" mode="click" options="[object Object]">
       <ol class="uk-nav uk-nav-default">
         <li>
           <router-link-stub tag="a" to="[object Object]">Deep</router-link-stub>

--- a/src/components/__snapshots__/OcDrop.spec.js.snap
+++ b/src/components/__snapshots__/OcDrop.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`OcDrop renders tippy 1`] = `
 <div>
   <p
+    aria-describedby="tippy-3"
     aria-expanded="true"
     id="trigger"
   >
@@ -95,6 +96,7 @@ exports[`OcDrop renders tippy 2`] = `
 exports[`OcDrop renders tippy 3`] = `
 <div>
   <p
+    aria-describedby="tippy-3"
     aria-expanded="true"
     id="trigger"
   >

--- a/src/components/__snapshots__/OcDrop.spec.js.snap
+++ b/src/components/__snapshots__/OcDrop.spec.js.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OcDrop renders tippy 1`] = `
+<div>
+  <p
+    aria-expanded="true"
+    id="trigger"
+  >
+    trigger
+  </p>
+  <div
+    data-tippy-root=""
+    id="tippy-3"
+    style="z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
+  >
+    <div
+      class="tippy-box"
+      data-animation="fade"
+      data-escaped=""
+      data-placement="top"
+      data-reference-hidden=""
+      data-state="visible"
+      data-theme="none"
+      role="tooltip"
+      style="max-width: 350px; transition-duration: 300ms;"
+      tabindex="-1"
+    >
+      <div
+        class="tippy-content"
+        data-state="visible"
+        style="transition-duration: 300ms;"
+      >
+        <div
+          class="oc-drop"
+          id="oc-drop-8"
+        >
+          <div
+            class="uk-card uk-card-default uk-card-small uk-card-body"
+          >
+            show
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OcDrop renders tippy 2`] = `
+<div>
+  <p
+    aria-expanded="false"
+    id="trigger"
+  >
+    trigger
+  </p>
+  <div
+    data-tippy-root=""
+    id="tippy-3"
+    style="z-index: 9999; visibility: hidden; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px); pointer-events: none;"
+  >
+    <div
+      class="tippy-box"
+      data-animation="fade"
+      data-escaped=""
+      data-placement="top"
+      data-reference-hidden=""
+      data-state="hidden"
+      data-theme="none"
+      role="tooltip"
+      style="max-width: 350px; transition-duration: 250ms;"
+      tabindex="-1"
+    >
+      <div
+        class="tippy-content"
+        data-state="hidden"
+        style="transition-duration: 250ms;"
+      >
+        <div
+          class="oc-drop"
+          id="oc-drop-8"
+        >
+          <div
+            class="uk-card uk-card-default uk-card-small uk-card-body"
+          >
+            show
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`OcDrop renders tippy 3`] = `
+<div>
+  <p
+    aria-expanded="true"
+    id="trigger"
+  >
+    trigger
+  </p>
+  <div
+    data-tippy-root=""
+    id="tippy-3"
+    style="z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
+  >
+    <div
+      class="tippy-box"
+      data-animation="fade"
+      data-escaped=""
+      data-placement="top"
+      data-reference-hidden=""
+      data-state="visible"
+      data-theme="none"
+      role="tooltip"
+      style="max-width: 350px; transition-duration: 300ms;"
+      tabindex="-1"
+    >
+      <div
+        class="tippy-content"
+        data-state="visible"
+        style="transition-duration: 300ms;"
+      >
+        <div
+          class="oc-drop"
+          id="oc-drop-8"
+        >
+          <div
+            class="uk-card uk-card-default uk-card-small uk-card-body"
+          >
+            show
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/directives/OcTooltip.js
+++ b/src/directives/OcTooltip.js
@@ -48,6 +48,9 @@ export default {
       interactive: true,
       ignoreAttributes: true,
       ...(Object.prototype.toString.call(value) === "[object Object]" && value),
+      aria: {
+        content: "describedby",
+      },
       plugins: [hideOnEsc],
     })
   },

--- a/src/directives/OcTooltip.js
+++ b/src/directives/OcTooltip.js
@@ -1,35 +1,34 @@
 import tippy from "tippy.js"
-
-const __logger = v => v
+import __logger from "../utils/logger"
 
 export const hideOnEsc = {
   name: "hideOnEsc",
   defaultValue: true,
   fn({ hide }) {
-    function onKeyDown(event) {
-      if (event.keyCode === 27) {
+    const onKeyDown = e => {
+      if (e.keyCode === 27) {
         hide()
       }
     }
 
     return {
-      onShow() {
+      onShow: () => {
         document.addEventListener("keydown", onKeyDown)
       },
-      onHide() {
+      onHide: () => {
         document.removeEventListener("keydown", onKeyDown)
       },
     }
   },
 }
 
-const destroy = el => {
-  if (!el._tippy) {
+export const destroy = _tippy => {
+  if (!_tippy) {
     return
   }
 
   try {
-    el._tippy.destroy()
+    _tippy.destroy()
   } catch (e) {
     __logger(e)
   }
@@ -42,7 +41,7 @@ export default {
       return
     }
 
-    destroy(el)
+    destroy(el._tippy)
 
     tippy(el, {
       content: value,
@@ -53,6 +52,6 @@ export default {
     })
   },
   unbind: function (el) {
-    destroy(el)
+    destroy(el._tippy)
   },
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,3 @@
+const __logger = v => v
+
+export default __logger

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,10 +1810,10 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.5.tgz#c131d88bd6713cc4d93b3bb1372edb1983225ff0"
   integrity sha512-gYsNoGkWejBxNO6SNRjOh/xKeZ0H0V+TFzaPzODfBjkAIb0aQgBuixC1brandC/CDJy1wYPwSoYrXpvul7m6yw==
 
-"@vue/test-utils@^1.0.0-beta.31":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.1.2.tgz#fdb487448dceefeaf3d01d465f7c836a3d666dbc"
-  integrity sha512-utbIL7zn9c+SjhybPwh48lpWCiluFCbP1yyRNAy1fQsw/6hiNFioaWy05FoVAFIZXC5WwBf+5r4ypfM1j/nI4A==
+"@vue/test-utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.2.0.tgz#3bc8c17ed549157275f0aec6b95da40887f7297f"
+  integrity sha512-poBTLqeJYNq1TXVhtVfnY8vELUVOFdJY8KZZoUuaAkIqPTWsxonU1M8nMWpZT+xEMrM+49+YcuEqtMHVD9Q9gw==
   dependencies:
     dom-event-types "^1.0.0"
     lodash "^4.17.15"


### PR DESCRIPTION
this pr replaces uk-drop by using tippy (same as tooltip directive).

The oc-drop api was kept intact so no changes by the consuming app expect importing tippy as peer dependency should be required.

It also keeps care that a11y (accessibility) usage of the web-ui is fulfilled.

Because it's not a breaking change it can be part of the upcoming 6.4.0 release.