### PR TITLE
Move tr height from prop to token

### DIFF
--- a/changelog/unreleased/enhancement-themable-tr-height
+++ b/changelog/unreleased/enhancement-themable-tr-height
@@ -1,0 +1,7 @@
+Enhancement: Themable Table Row Height
+
+By moving the table row height from a component property to a themable variable, 
+we give users of the web frontend a way to customize the appearance of their UI 
+(instead of only giving the freedom to users of the ODS).
+
+https://github.com/owncloud/owncloud-design-system/pull/1291

--- a/src/components/table/OcTable.vue
+++ b/src/components/table/OcTable.vue
@@ -148,14 +148,6 @@ export default {
       default: null,
     },
     /**
-     * Height of the row in pixels
-     */
-    rowHeight: {
-      type: Number,
-      required: false,
-      default: 64,
-    },
-    /**
      * Top position of header used when the header is sticky in pixels
      */
     headerPosition: {
@@ -256,7 +248,6 @@ export default {
           this.isHighlighted(item) ? "oc-table-highlighted" : undefined,
           this.isDisabled(item) ? "oc-table-disabled" : undefined,
         ].filter(Boolean),
-        style: { height: `${this.rowHeight}px` },
       }
     },
     extractTdProps(field, index) {
@@ -342,6 +333,10 @@ export default {
 
   &-hover tr {
     transition: background-color $transition-duration-short ease-in-out;
+  }
+
+  tr {
+    height: var(--oc-size-height-table-row);
   }
 
   tr + tr {

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -4,7 +4,6 @@
     :fields="fields"
     :highlighted="highlighted"
     :disabled="disabled"
-    :row-height="rowHeight"
     :sticky="true"
     :header-position="headerPosition"
     @highlight="showDetails"
@@ -168,14 +167,6 @@ export default {
       type: [String, Array],
       required: false,
       default: null,
-    },
-    /**
-     * Height of the row in pixels
-     */
-    rowHeight: {
-      type: Number,
-      required: false,
-      default: 64,
     },
     /**
      * Target route path used to build the link when navigating into a resource

--- a/src/components/table/__snapshots__/OcTable.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTable.spec.js.snap
@@ -14,7 +14,7 @@ exports[`OcTable displays all field types 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-4b136c0a-5057-11eb-ac70-eba264112003" style="height: 64px;">
+    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-4b136c0a-5057-11eb-ac70-eba264112003">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-table-data-cell oc-table-data-cell-id oc-pl-s ">4b136c0a-5057-11eb-ac70-eba264112003</td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-table-data-cell oc-table-data-cell-resource">
         <div class="slot"><span>
@@ -25,7 +25,7 @@ exports[`OcTable displays all field types 1`] = `
         Double of 2 is 4
       </td>
     </tr>
-    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-8468c9f0-5057-11eb-924b-934c6fd827a2" style="height: 64px;">
+    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-8468c9f0-5057-11eb-924b-934c6fd827a2">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-table-data-cell oc-table-data-cell-id oc-pl-s ">8468c9f0-5057-11eb-924b-934c6fd827a2</td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-table-data-cell oc-table-data-cell-resource">
         <div class="slot"><span>
@@ -36,7 +36,7 @@ exports[`OcTable displays all field types 1`] = `
         Double of 6 is 12
       </td>
     </tr>
-    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-9c4cf97e-5057-11eb-8044-b3d5df9caa21" style="height: 64px;">
+    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-9c4cf97e-5057-11eb-8044-b3d5df9caa21">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-table-data-cell oc-table-data-cell-id oc-pl-s ">9c4cf97e-5057-11eb-8044-b3d5df9caa21</td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-auto oc-table-data-cell oc-table-data-cell-resource">
         <div class="slot"><span>
@@ -56,21 +56,21 @@ exports[`OcTable hides header 1`] = `
 <table class="oc-table">
   <!---->
   <oc-tbody-stub>
-    <oc-tr-stub class="oc-tbody-tr oc-tbody-tr-4b136c0a-5057-11eb-ac70-eba264112003" style="height: 64px;">
+    <oc-tr-stub class="oc-tbody-tr oc-tbody-tr-4b136c0a-5057-11eb-ac70-eba264112003">
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-id oc-pl-s ">4b136c0a-5057-11eb-ac70-eba264112003</oc-td-stub>
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-resource"></oc-td-stub>
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-doubled oc-pr-s">
         Double of 2 is 4
       </oc-td-stub>
     </oc-tr-stub>
-    <oc-tr-stub class="oc-tbody-tr oc-tbody-tr-8468c9f0-5057-11eb-924b-934c6fd827a2" style="height: 64px;">
+    <oc-tr-stub class="oc-tbody-tr oc-tbody-tr-8468c9f0-5057-11eb-924b-934c6fd827a2">
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-id oc-pl-s ">8468c9f0-5057-11eb-924b-934c6fd827a2</oc-td-stub>
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-resource"></oc-td-stub>
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-doubled oc-pr-s">
         Double of 6 is 12
       </oc-td-stub>
     </oc-tr-stub>
-    <oc-tr-stub class="oc-tbody-tr oc-tbody-tr-9c4cf97e-5057-11eb-8044-b3d5df9caa21" style="height: 64px;">
+    <oc-tr-stub class="oc-tbody-tr oc-tbody-tr-9c4cf97e-5057-11eb-8044-b3d5df9caa21">
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-id oc-pl-s ">9c4cf97e-5057-11eb-8044-b3d5df9caa21</oc-td-stub>
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-resource"></oc-td-stub>
       <oc-td-stub alignh="left" alignv="middle" width="auto" class="oc-table-data-cell oc-table-data-cell-doubled oc-pr-s">

--- a/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
+++ b/src/components/table/__snapshots__/OcTableFiles.spec.js.snap
@@ -34,7 +34,7 @@ exports[`OcTableFiles displays all fields 1`] = `
     </tr>
   </thead>
   <tbody>
-    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-forest" style="height: 64px;">
+    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-forest">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select oc-pl-s "><span><input id="oc-table-files-select-forest" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-forest" class="oc-invisible-sr oc-cursor-pointer">Select file</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><img src="https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg" alt="" aria-hidden="true" loading="eager" width="40" height="40" class="oc-resource-preview">
@@ -81,7 +81,7 @@ exports[`OcTableFiles displays all fields 1`] = `
         <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false">6:1: text data outside of root node.</svg></span></button></div>
       </td>
     </tr>
-    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-notes" style="height: 64px;">
+    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-notes">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select oc-pl-s "><span><input id="oc-table-files-select-notes" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-notes" class="oc-invisible-sr oc-cursor-pointer">Select file</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false">6:1: text data outside of root node.</svg></span>
@@ -128,7 +128,7 @@ exports[`OcTableFiles displays all fields 1`] = `
         <div class="oc-table-files-actions"> <button aria-label="Show details" class="oc-table-files-btn-show-details oc-button oc-button-m oc-button-justify-content-center oc-button-gap-m oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-m oc-icon-passive"><svg aria-hidden="true" focusable="false">6:1: text data outside of root node.</svg></span></button></div>
       </td>
     </tr>
-    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-documents" style="height: 64px;">
+    <tr tabindex="-1" class="oc-tbody-tr oc-tbody-tr-documents">
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-shrink oc-table-data-cell oc-table-data-cell-select oc-pl-s "><span><input id="oc-table-files-select-documents" type="checkbox" name="checkbox" class="oc-checkbox oc-checkbox-l" value="[object Object]"> <label for="oc-table-files-select-documents" class="oc-invisible-sr oc-cursor-pointer">Select folder</label></span></td>
       <td class="oc-td oc-table-cell oc-table-cell-align-left oc-table-cell-align-middle oc-table-cell-width-expand oc-text-truncate oc-table-data-cell oc-table-data-cell-name">
         <div class="oc-resource oc-text-overflow"><span class="oc-icon oc-icon-l oc-icon-passive"><svg aria-hidden="true" focusable="false">6:1: text data outside of root node.</svg></span>

--- a/src/tokens/ods/size.yaml
+++ b/src/tokens/ods/size.yaml
@@ -3,6 +3,8 @@ size:
   height:
     small:
       value: 50px
+    table-row:
+      value: 64px
   width:
     medium:
       value: 300px


### PR DESCRIPTION
First idea was to use existing padding/margin classes, however they don't properly work in table rows plus re-using the generic spacing classes to configure a more dense/lofty table row will yield unwanted results in the rest of the UI so I went for introducing a dedicated table row height CSS variable