### PR TITLE
Change OcSidebarNav active and hover colors

### DIFF
--- a/changelog/unreleased/enhancement-active-nav
+++ b/changelog/unreleased/enhancement-active-nav
@@ -1,0 +1,5 @@
+Enhancement: Color contrast for OcSidebarNav
+
+We've set different colors for the active and hover state of nav items in the OcSidebarNav component. Those colors now fulfill required color contrast ratios.
+
+https://github.com/owncloud/owncloud-design-system/pull/1310

--- a/src/components/OcSidebarNavItem.vue
+++ b/src/components/OcSidebarNavItem.vue
@@ -64,6 +64,8 @@ export default {
 .oc-sidebar-nav-item {
   &-link {
     align-items: center;
+    border-left: 1px solid transparent;
+    border-right: 1px solid transparent;
     color: var(--oc-color-text-inverse);
     display: flex;
     font-weight: 600;
@@ -71,14 +73,25 @@ export default {
     transition: background-color $transition-duration-short ease-in-out;
 
     &:hover {
-      background-color: var(--oc-color-swatch-brand-hover);
-      color: var(--oc-color-text-inverse);
+      background-color: var(--oc-color-swatch-inverse-default);
+      border-left: 1px solid var(--oc-color-swatch-brand-default);
+      border-right: 1px solid var(--oc-color-swatch-brand-default);
+      color: var(--oc-color-text-default);
       text-decoration: none;
+    }
+    &:hover > .oc-icon > svg {
+      fill: var(--oc-color-text-default) !important;
     }
 
     &.active {
-      background-color: var(--oc-color-swatch-brand-hover);
+      background-color: var(--oc-color-swatch-inverse-default);
+      border-left: 1px solid var(--oc-color-swatch-brand-default);
+      border-right: 1px solid var(--oc-color-swatch-brand-default);
+      color: var(--oc-color-text-default);
       cursor: default;
+    }
+    &.active > .oc-icon > svg {
+      fill: var(--oc-color-text-default) !important;
     }
   }
 


### PR DESCRIPTION
This PR switches background color for nav items in `hover` and `active` state within the `OcSidebarNav` component, now fulfilling required color contrasts for WCAG 2.1 AA.

Up for discussion if white is too heavy.

<img width="1918" alt="Screenshot 2021-05-19 at 21 59 20" src="https://user-images.githubusercontent.com/3532843/118877077-48eab280-b8ee-11eb-8784-aa5240a2242d.png">

<img width="1920" alt="Screenshot 2021-05-19 at 21 59 04" src="https://user-images.githubusercontent.com/3532843/118877053-42f4d180-b8ee-11eb-9278-16483c582f5e.png">
