### PR TITLE
Remove background color transition in sidebar nav

### DIFF
--- a/changelog/unreleased/enhancement-active-nav
+++ b/changelog/unreleased/enhancement-active-nav
@@ -3,3 +3,4 @@ Enhancement: Color contrast for OcSidebarNav
 We've set different colors for the active and hover state of nav items in the OcSidebarNav component. Those colors now fulfill required color contrast ratios.
 
 https://github.com/owncloud/owncloud-design-system/pull/1310
+https://github.com/owncloud/owncloud-design-system/pull/1315

--- a/src/components/OcSidebarNavItem.vue
+++ b/src/components/OcSidebarNavItem.vue
@@ -70,7 +70,6 @@ export default {
     display: flex;
     font-weight: 600;
     padding: var(--oc-space-small) var(--oc-space-medium);
-    transition: background-color $transition-duration-short ease-in-out;
 
     &:hover {
       background-color: var(--oc-color-swatch-inverse-default);


### PR DESCRIPTION
This PR removes the background color transition in the sidebar nav items, since it turned out to be too heavy now with high contrast colors.