### PR TITLE
Fix hover svg fill in OcButton

### DIFF
--- a/changelog/unreleased/enhancement-a11y-color-contrasts
+++ b/changelog/unreleased/enhancement-a11y-color-contrasts
@@ -4,3 +4,4 @@ The color contrast checker now runs when generating tokens via the yarn token co
 and reports if any colors don't match the minimum color contrast
 
 https://github.com/owncloud/owncloud-design-system/pull/1302
+https://github.com/owncloud/owncloud-design-system/pull/1316

--- a/src/components/OcButton.vue
+++ b/src/components/OcButton.vue
@@ -266,7 +266,7 @@ export default {
     border-color: $color;
 
     .oc-icon > svg {
-      fill: $muted-color;
+      fill: var(--oc-color-text-inverse);
     }
   }
 }
@@ -360,7 +360,6 @@ export default {
 
   .oc-icon > svg {
     fill: var(--oc-color-text-inverse);
-    transition: fill $transition-duration-short ease-in-out;
   }
 
   &-passive {


### PR DESCRIPTION
This PR fixes that icons in OcButtons were not flipped to the inverse text color on hover. Again, the color transition was too harsh with high contrast, so I removed it.