### PR TITLE
reduce fileslist row height

### DIFF
--- a/changelog/unreleased/enhancement-reduce-fileslist-row-height
+++ b/changelog/unreleased/enhancement-reduce-fileslist-row-height
@@ -1,0 +1,5 @@
+Enhancement: reduce the height of the filelist rows
+
+We've reduced the height of the filelist rows to the possible minimum to provide a more condensed view especially for desktop users. The possible minimum of the filelist row is currently determined by the height of the filename and the sharing-indicators below the filename.
+
+https://github.com/owncloud/owncloud-design-system/pull/1319

--- a/src/components/table/_OcTableCell.vue
+++ b/src/components/table/_OcTableCell.vue
@@ -55,7 +55,7 @@ export default {
 <style lang="scss">
 .oc-table-cell {
   /* padding is not configurable until we need it */
-  padding: var(--oc-space-xsmall);
+  padding: 0px var(--oc-space-xsmall);
   position: relative;
 
   &-align {

--- a/src/components/table/_OcTableCell.vue
+++ b/src/components/table/_OcTableCell.vue
@@ -55,7 +55,7 @@ export default {
 <style lang="scss">
 .oc-table-cell {
   /* padding is not configurable until we need it */
-  padding: 0px var(--oc-space-xsmall);
+  padding: 0 var(--oc-space-xsmall);
   position: relative;
 
   &-align {

--- a/src/tokens/ods/size.yaml
+++ b/src/tokens/ods/size.yaml
@@ -4,7 +4,7 @@ size:
     small:
       value: 50px
     table-row:
-      value: 64px
+      value: 49px
   width:
     medium:
       value: 300px


### PR DESCRIPTION
# description
issue: https://github.com/owncloud/web/issues/5078
**problem:** row height is limited by the sharing indicators.

this PR sets the row height to the minimum possible with the sharing-indicators still placed below the filename. it is meant as a quickfix to reduce the filelist-height.

please review carefully, newbie PR :-)

![image](https://user-images.githubusercontent.com/26610733/119160063-2bd1f300-ba58-11eb-80b9-155001aaccb9.png)
![image](https://user-images.githubusercontent.com/26610733/119160094-31c7d400-ba58-11eb-993b-89c28ecb44e2.png)
![image](https://user-images.githubusercontent.com/26610733/119160121-38eee200-ba58-11eb-95e9-4dd8fbc9792b.png)
