### PR TITLE
Text input clear

### DIFF
--- a/changelog/unreleased/enhancement-text-input-clear
+++ b/changelog/unreleased/enhancement-text-input-clear
@@ -1,0 +1,5 @@
+Enhancement: Clear button for OcTextInput
+
+The OcTextInput component now has an optional button for clearing the input.
+
+https://github.com/owncloud/owncloud-design-system/pull/1329

--- a/src/components/OcTextInput.spec.js
+++ b/src/components/OcTextInput.spec.js
@@ -2,60 +2,66 @@ import { shallowMount, mount } from "@vue/test-utils"
 import OcTextInput from "./OcTextInput.vue"
 
 const defaultProps = {
-  label: "label"
+  label: "label",
 }
 
 describe("OcTextInput", () => {
   describe("clear input", () => {
-    it('has no clear button when it is disabled', () => {
+    it("has no clear button when it is disabled", () => {
       const wrapper = shallowMount(OcTextInput, {
         propsData: {
           ...defaultProps,
-          value: "non-empty-value"
-        }
+          value: "non-empty-value",
+        },
       })
 
       expect(wrapper.find(".oc-text-input-btn-clear").exists()).toBeFalsy()
     })
 
-    it('has no clear button when it is enabled but the input is empty', () => {
+    it("has no clear button when it is enabled but the input is empty", () => {
       const wrapper = shallowMount(OcTextInput, {
         propsData: {
           ...defaultProps,
           clearButtonEnabled: true,
-          value: ""
-        }
+          value: "",
+        },
       })
 
       expect(wrapper.find(".oc-text-input-btn-clear").exists()).toBeFalsy()
     })
 
-    it('has a clear button when it is enabled and the input contains content', () => {
+    it("has a clear button when it is enabled and the input contains content", () => {
       const wrapper = shallowMount(OcTextInput, {
         propsData: {
           ...defaultProps,
           clearButtonEnabled: true,
-          value: "non-empty-value"
-        }
+          value: "non-empty-value",
+        },
       })
 
       const btn = wrapper.find(".oc-text-input-btn-clear")
       expect(btn.exists()).toBeTruthy()
     })
 
-    it('clears the content on click', async () => {
+    it("clears the content on click", async () => {
       const wrapper = mount(OcTextInput, {
         propsData: {
           ...defaultProps,
           clearButtonEnabled: true,
-          value: "non-empty-value"
-        }
+          value: "non-empty-value",
+        },
+        attachTo: document.body,
       })
 
       const btn = wrapper.find(".oc-text-input-btn-clear")
-      btn.trigger('click')
+      const input = wrapper.find(".oc-text-input")
+
+      btn.trigger("click")
       await wrapper.vm.$nextTick()
+
       expect(wrapper.emitted().input[0][0]).toEqual("")
+      expect(input.element.value).toEqual("")
+      expect(document.activeElement.id).toBe(input.element.id)
     })
   })
 })

--- a/src/components/OcTextInput.spec.js
+++ b/src/components/OcTextInput.spec.js
@@ -1,0 +1,61 @@
+import { shallowMount, mount } from "@vue/test-utils"
+import OcTextInput from "./OcTextInput.vue"
+
+const defaultProps = {
+  label: "label"
+}
+
+describe("OcTextInput", () => {
+  describe("clear input", () => {
+    it('has no clear button when it is disabled', () => {
+      const wrapper = shallowMount(OcTextInput, {
+        propsData: {
+          ...defaultProps,
+          value: "non-empty-value"
+        }
+      })
+
+      expect(wrapper.find(".oc-text-input-btn-clear").exists()).toBeFalsy()
+    })
+
+    it('has no clear button when it is enabled but the input is empty', () => {
+      const wrapper = shallowMount(OcTextInput, {
+        propsData: {
+          ...defaultProps,
+          clearButtonEnabled: true,
+          value: ""
+        }
+      })
+
+      expect(wrapper.find(".oc-text-input-btn-clear").exists()).toBeFalsy()
+    })
+
+    it('has a clear button when it is enabled and the input contains content', () => {
+      const wrapper = shallowMount(OcTextInput, {
+        propsData: {
+          ...defaultProps,
+          clearButtonEnabled: true,
+          value: "non-empty-value"
+        }
+      })
+
+      const btn = wrapper.find(".oc-text-input-btn-clear")
+      expect(btn.exists()).toBeTruthy()
+    })
+
+    it('clears the content on click', async () => {
+      const wrapper = mount(OcTextInput, {
+        propsData: {
+          ...defaultProps,
+          clearButtonEnabled: true,
+          value: "non-empty-value"
+        }
+      })
+
+      const btn = wrapper.find(".oc-text-input-btn-clear")
+      btn.trigger('click')
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted().input[0][0]).toEqual("")
+    })
+  })
+})

--- a/src/components/OcTextInput.vue
+++ b/src/components/OcTextInput.vue
@@ -215,6 +215,7 @@ export default {
     },
     onClear() {
       this.$refs.input.value = ""
+      this.$refs.input.focus()
       this.onInput("")
     },
     onInput(value) {

--- a/src/components/OcTextInput.vue
+++ b/src/components/OcTextInput.vue
@@ -1,22 +1,33 @@
 <template>
   <div>
     <label class="oc-label" :for="id" v-text="label" />
-    <input
-      :id="id"
-      v-bind="additionalAttributes"
-      ref="input"
-      :aria-invalid="ariaInvalid"
-      :class="{
-        'oc-text-input': !stopClassPropagation,
-        'oc-text-input-warning': !!warningMessage,
-        'oc-text-input-danger': !!errorMessage,
-      }"
-      :type="type"
-      :value="value"
-      v-on="listeners"
-      @input="onInput($event.target.value)"
-      @focus="onFocus($event.target)"
-    />
+    <div class="uk-position-relative">
+      <input
+        :id="id"
+        v-bind="additionalAttributes"
+        ref="input"
+        :aria-invalid="ariaInvalid"
+        :class="{
+          'oc-text-input': !stopClassPropagation,
+          'oc-text-input-warning': !!warningMessage,
+          'oc-text-input-danger': !!errorMessage,
+        }"
+        :type="type"
+        :value="value"
+        v-on="listeners"
+        @input="onInput($event.target.value)"
+        @focus="onFocus($event.target)"
+      />
+      <oc-button
+        v-if="showClearButton"
+        :aria-label="clearButtonAccessibleLabelValue"
+        class="uk-position-small uk-position-center-right oc-text-input-btn-clear"
+        appearance="raw"
+        @click="onClear"
+      >
+        <oc-icon name="close" size="small" variation="passive" />
+      </oc-button>
+    </div>
     <div v-if="showMessageLine" class="oc-text-input-message">
       <span
         :id="messageId"
@@ -33,6 +44,8 @@
 
 <script>
 import uniqueId from "../utils/uniqueId"
+import OcButton from "./OcButton"
+import OcIcon from "./OcIcon"
 
 /**
  * Form Inputs are used to allow users to provide text input when the expected
@@ -49,6 +62,7 @@ import uniqueId from "../utils/uniqueId"
  */
 export default {
   name: "OcTextInput",
+  components: { OcIcon, OcButton },
   status: "review",
   release: "1.0.0",
   inheritAttrs: false,
@@ -80,6 +94,22 @@ export default {
       type: String,
       required: false,
       default: null,
+    },
+    /**
+     * Whether or not the input element should have a dedicated button for clearing the input content.
+     */
+    clearButtonEnabled: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    /**
+     * The aria label for the clear button. Only used if it's enabled at all.
+     */
+    clearButtonAccessibleLabel: {
+      type: String,
+      required: false,
+      default: "",
     },
     /**
      * Accessible of the form input field, via aria-label.
@@ -168,6 +198,12 @@ export default {
 
       return this.descriptionMessage
     },
+    showClearButton() {
+      return this.clearButtonEnabled && this.value && this.value.length > 0
+    },
+    clearButtonAccessibleLabelValue() {
+      return this.clearButtonAccessibleLabel || this.$gettext("Clear input")
+    },
   },
   methods: {
     /**
@@ -176,6 +212,10 @@ export default {
      */
     focus() {
       this.$refs.input.focus()
+    },
+    onClear() {
+      this.$refs.input.value = ""
+      this.onInput("")
     },
     onInput(value) {
       /**
@@ -265,6 +305,7 @@ export default {
       <oc-text-input label="Focus field" ref="inputForFocus"/>
       <oc-button @click="_focusAndSelect">Focus and select input below</oc-button>
       <oc-text-input label="Select field" value="Will you select this existing text?" ref="inputForFocusSelect"/>
+      <oc-text-input label="Clear input" v-model="inputValueForClearing" :clear-button-enabled="true" />
       <h3 class="uk-heading-divider">
         Messages
       </h3>
@@ -297,6 +338,7 @@ export default {
         return {
           inputValue: 'initial',
           valueForMessages: '',
+          inputValueForClearing: 'clear me',
         }
       },
       computed: {

--- a/src/components/__snapshots__/OcModal.spec.js.snap
+++ b/src/components/__snapshots__/OcModal.spec.js.snap
@@ -9,7 +9,7 @@ exports[`OcModal displays input 1`] = `
         <h2 id="oc-modal-title">Create new folder</h2>
       </div>
       <div class="oc-modal-body">
-        <oc-text-input-stub id="oc-textinput-1" type="text" value="New folder" label="Folder name" fixmessageline="true" class="oc-modal-body-input"></oc-text-input-stub>
+        <oc-text-input-stub id="oc-textinput-1" type="text" value="New folder" clearbuttonaccessiblelabel="" label="Folder name" fixmessageline="true" class="oc-modal-body-input"></oc-text-input-stub>
         <div class="oc-modal-body-actions uk-flex uk-flex-right">
           <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
           <oc-button-stub type="button" size="medium" variation="passive" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>


### PR DESCRIPTION
Adding an optional clear button to the OcTextInput component. It has a default aria-label (`Clear input`) which can be overridden via a prop. Button can be reached via keyboard navigation and used via `ENTER` key or via click. Using the button clears the text input and emits an `input` event with an empty string.

<img width="412" alt="Screenshot 2021-05-27 at 14 45 45" src="https://user-images.githubusercontent.com/3532843/119828584-983a6f80-befa-11eb-8dd9-b99bb7630a56.png">
<img width="407" alt="Screenshot 2021-05-27 at 14 45 56" src="https://user-images.githubusercontent.com/3532843/119828589-996b9c80-befa-11eb-90c1-0b464ad4e337.png">
<img width="406" alt="Screenshot 2021-05-27 at 14 46 04" src="https://user-images.githubusercontent.com/3532843/119828591-996b9c80-befa-11eb-846b-81cc606aa238.png">
