### PR TITLE
Disable interactive prop in tippy

### DIFF
--- a/changelog/unreleased/bugfix-tippy-non-interactive
+++ b/changelog/unreleased/bugfix-tippy-non-interactive
@@ -1,0 +1,5 @@
+Bugfix: Non-interactive tooltips
+
+Interactive tooltips were breaking correct z-index behaviour so we set them to non-interactive.
+
+https://github.com/owncloud/owncloud-design-system/pull/1330

--- a/src/directives/OcTooltip.js
+++ b/src/directives/OcTooltip.js
@@ -59,7 +59,6 @@ const initOrUpdate = (el, { value = {} }, { elm }) => {
 
   const props = merge.all([
     {
-      interactive: true,
       ignoreAttributes: true,
       aria: {
         content: null,


### PR DESCRIPTION
Disabling interactivity in tooltips.

Fixes https://github.com/owncloud/owncloud-design-system/issues/1321