### PR TITLE
[tests-only] Added unit tests for oc button

### DIFF
--- a/src/components/OcButton.spec.js
+++ b/src/components/OcButton.spec.js
@@ -1,0 +1,193 @@
+import OcButton from "./OcButton.vue"
+import { createLocalVue, shallowMount } from "@vue/test-utils"
+const localVue = createLocalVue()
+
+/**
+ * There are some errors that should be caught but sneaked by vue.
+ * Vue Warn errors is one of them
+ *
+ * Global console contains these error from where we can assert if they are expected errors
+ */
+beforeEach(() => {
+  const { error } = global.console
+  global.console.error = (...args) => {
+    for (let i = 0; i < args.length; i += 1) {
+      const arg = args[i]
+      if (typeof arg === "string" && arg.includes("Vue warn")) {
+        // Vue warn contains messages with warning initiator element
+        // Only vue warn message is thrown
+        const errorSplit = arg.split("\n")
+        throw errorSplit[0]
+      }
+    }
+    error(...args)
+  }
+})
+
+describe("OcButton", () => {
+  const testSlots = { default: '<p class="text">Test button</p>' }
+  function getWrapperWithProps(props) {
+    return shallowMount(OcButton, { localVue: localVue, propsData: props })
+  }
+  function getWrapperWithTestSlot() {
+    return shallowMount(OcButton, { localVue: localVue, slots: testSlots })
+  }
+
+  it("should display slot html", () => {
+    const wrapper = getWrapperWithTestSlot()
+    const slot = wrapper.find("p")
+    expect(slot).toBeTruthy()
+    expect(slot.attributes("class")).toBe("text")
+    expect(slot.text()).toBe("Test button")
+  })
+
+  it("can stop class propagation", () => {
+    const wrapper = getWrapperWithProps({
+      stopClassPropagation: true,
+      size: "medium",
+    })
+    expect(wrapper.attributes("class")).toBe("")
+  })
+
+  describe("click event", () => {
+    it("should emit click event when click is triggered", async () => {
+      const wrapper = getWrapperWithProps({})
+      await wrapper.trigger("click")
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted("click")).toBeTruthy()
+    })
+    it.each`
+      type
+      ${"a"}
+      ${"router-link"}
+    `("should not emit click event when type is $type", async ({ type }) => {
+      const wrapper = getWrapperWithProps({ type: type })
+      await wrapper.trigger("click")
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted("click")).toBeFalsy()
+    })
+  })
+  describe("when oc button is disabled", () => {
+    let wrapper
+    beforeEach(() => {
+      wrapper = getWrapperWithProps({ disabled: true })
+    })
+    it("should have disabled attribute set to disabled", () => {
+      expect(wrapper.attributes("disabled")).toBe("disabled")
+    })
+    it("should not emit click event", async () => {
+      await wrapper.trigger("click")
+      await wrapper.vm.$nextTick()
+      expect(wrapper.emitted("click")).toBeFalsy()
+    })
+  })
+  describe("different types of button", () => {
+    it.each`
+      type             | expectLink | expectButton | expectRouterLink
+      ${"a"}           | ${true}    | ${false}     | ${false}
+      ${"button"}      | ${false}   | ${true}      | ${false}
+      ${"router-link"} | ${false}   | ${false}     | ${true}
+    `("can behave as a $type", ({ type, expectLink, expectButton, expectRouterLink }) => {
+      const wrapper = getWrapperWithProps({ type: type })
+      expect(wrapper.find("a").exists()).toBe(expectLink)
+      expect(wrapper.find("button").exists()).toBe(expectButton)
+      expect(wrapper.find("router-link-stub").exists()).toBe(expectRouterLink)
+    })
+  })
+  describe("different sizes of button", () => {
+    it.each`
+      size         | expectedClass
+      ${"small"}   | ${"oc-button-s"}
+      ${"medium"}  | ${"oc-button-m"}
+      ${"large"}   | ${"oc-button-l"}
+      ${"x-small"} | ${"oc-button-undefined"}
+    `(
+      "when size prop is set as $size class $expectedClass should be assigned",
+      ({ size, expectedClass }) => {
+        const wrapper = getWrapperWithProps({
+          size: size,
+        })
+        expect(wrapper.attributes("class")).toContain(expectedClass)
+      }
+    )
+  })
+  describe("default prop values", () => {
+    /* eslint-disable no-unused-vars */
+    it.each`
+      name                 | expected
+      ${"size"}            | ${"oc-button-m"}
+      ${"variation"}       | ${"oc-button-passive"}
+      ${"justify content"} | ${"oc-button-justify-content-center"}
+      ${"gap size"}        | ${"oc-button-gap-m"}
+      ${"appearance"}      | ${"oc-button-passive-outline"}
+    `('should have attribute "$name" as "$expected"', ({ name, expected }) => {
+      const wrapper = getWrapperWithProps({})
+      expect(wrapper.attributes("class")).toContain(expected)
+    })
+    /* eslint-disable no-unused-vars */
+  })
+  describe("invalid prop value", () => {
+    it.each`
+      prop
+      ${"appearance"}
+      ${"size"}
+      ${"submit"}
+      ${"justifyContent"}
+      ${"variation"}
+      ${"gapSize"}
+    `('when prop "$prop" is set an invalid value"', ({ prop, value }) => {
+      try {
+        let props = {}
+        props[prop] = "not-valid"
+        getWrapperWithProps(props)
+        throw new Error(`Provided value "${value}" for prop "${prop}" is valid.`)
+      } catch (e) {
+        expect(e).toContain(
+          `[Vue warn]: Invalid prop: custom validator check failed for prop "${prop}".`
+        )
+      }
+    })
+    it('when invalid value is set for prop "type"', () => {
+      try {
+        getWrapperWithProps({
+          type: "not-valid",
+        })
+        throw new Error(`Provided value for prop "type" is valid.`)
+      } catch (e) {
+        /* eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect */
+        expect(e).toContain(
+          "[Vue warn]: Unknown custom element: <not-valid> - did you register the" +
+            ' component correctly? For recursive components, make sure to provide the "name" option.'
+        )
+      }
+    })
+  })
+  describe("oc button appearance", () => {
+    // appearance prop is combined with variation prop
+    describe('when appearance is "filled"', () => {
+      it("should not have extra appearance class", () => {
+        const wrapper = getWrapperWithProps({
+          appearance: "filled",
+        })
+        expect(wrapper.attributes("class")).toContain("oc-button-passive")
+        expect(wrapper.attributes("class")).not.toContain("oc-button-passive-raw")
+        expect(wrapper.attributes("class")).not.toContain("oc-button-passive-outline")
+      })
+    })
+    describe("when oc button is initialized with variation and appearance", () => {
+      it.each`
+        variation    | appearance   | expectedClass
+        ${"success"} | ${"raw"}     | ${"oc-button-success oc-button-success-raw"}
+        ${"success"} | ${"outline"} | ${"oc-button-success oc-button-success-outline"}
+        ${"primary"} | ${"raw"}     | ${"oc-button-primary oc-button-primary-raw"}
+        ${"primary"} | ${"outline"} | ${"oc-button-primary-outline"}
+      `("it should have extra appearance class", ({ variation, appearance, expectedClass }) => {
+        const wrapper = getWrapperWithProps({
+          appearance: appearance,
+          variation: variation,
+        })
+        expect(wrapper.attributes("class")).toContain(expectedClass)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description
tests if
- button emits click event on click
- button is not clickable while disabled
- button can show provided slot

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/web/issues/5217
- #1366 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
