### PR TITLE
[tests-only] Add custom clone step

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -34,14 +34,29 @@ def testing(ctx):
             'os': 'linux',
             'arch': 'amd64',
         },
+        "clone": {
+            # The default drone clone step "internally auto-merges" the PR branch to master.
+            # That confuses SonarCloud. The analysis report does not come from the actual
+            # real commit at the tip of the branch.
+            "disable": True,
+        },
         'steps': [
+            {
+                 'name': 'clone',
+                 'image': 'owncloudci/alpine:latest',
+                 'commands': [
+                     'git clone https://github.com/%s.git .' % (repo_slug),
+                     'git checkout $DRONE_COMMIT',
+                 ]
+            },
             {
                 'name': 'dependencies',
                 'image': 'owncloudci/nodejs:14',
                 'pull': 'always',
                 'commands': [
                     'yarn install'
-                ]
+                ],
+                'depends_on': ['clone']
             },
             {
                 'name': 'eslint',

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ yarn-error.log*
 
 # Ignore compiled tokens
 src/assets/tokens/
+
+# Ignore SonarCloud output
+.scannerwork


### PR DESCRIPTION
## Description
Disabled the built-in clone step of drone. Provide out own clone step that just checks out the commit from the PR and does not do any merge-forward to tip of master. That should help SonarCloud to match up the analysis based on a commit ID that matches the commit ID in the PR/branch on GitHub.

This applies code similar to https://github.com/owncloud/web/pull/5223

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
