### PR TITLE
Fix/improve table sorting

### DIFF
--- a/changelog/unreleased/enhancement-sortable-string-and-function
+++ b/changelog/unreleased/enhancement-sortable-string-and-function
@@ -1,0 +1,6 @@
+Enhancement: Table Sorting by String or Function
+
+Sorting inside the OcTable now can be done by passing a string or a function, 
+so you can e.g. sort objects inside Array by their properties.
+
+https://github.com/owncloud/owncloud-design-system/pull/1377

--- a/jest.conf.js
+++ b/jest.conf.js
@@ -18,7 +18,7 @@ module.exports = {
   snapshotSerializers: ["<rootDir>/node_modules/jest-serializer-vue"],
   coverageDirectory: "<rootDir>/coverage",
   collectCoverageFrom: [
-    "<rootDir>/src/components/**/*.vue",
+    "<rootDir>/src/components/**/*.{js,vue}",
     "<rootDir>/src/utils/**/*.{js,vue}",
     "<rootDir>/src/system.js",
     "<rootDir>/docs/**/*.{js,vue}",

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -287,7 +287,7 @@ export default {
             type: "slot",
             alignH: "right",
             wrap: "nowrap",
-            sortable: true,
+            sortable: "displayName",
           },
           {
             name: "mdate",

--- a/src/components/table/OcTableFilesSort.spec.js
+++ b/src/components/table/OcTableFilesSort.spec.js
@@ -1,0 +1,290 @@
+import { mount } from "@vue/test-utils"
+import { DateTime } from "luxon"
+
+import Table from "./OcTableFiles.vue"
+
+const ASC = "ascending"
+const DESC = "descending"
+const NONE = "none"
+
+function todayMinusDays(daysPassed) {
+  return DateTime.fromJSDate(new Date())
+    .minus({ days: daysPassed })
+    .toFormat("EEE, dd MMM yyyy HH:mm:ss")
+}
+
+const mdate1 = todayMinusDays(4)
+const sdate1 = todayMinusDays(3)
+const ddate1 = todayMinusDays(1)
+
+const mdate2 = todayMinusDays(0)
+const sdate2 = todayMinusDays(3)
+const ddate2 = todayMinusDays(1)
+
+const mdate3 = todayMinusDays(3)
+const sdate3 = todayMinusDays(3)
+const ddate3 = todayMinusDays(1)
+
+const sharedWithOne = [
+  {
+    id: "bob",
+    username: "bob",
+    displayName: "Bob",
+  },
+]
+
+const sharedWithTwo = [
+  {
+    id: "marie",
+    username: "marie",
+    displayName: "Marie",
+  },
+  {
+    id: "john",
+    username: "john",
+    displayName: "John Richards Emperor of long names",
+  },
+]
+
+const sharedWithThree = [
+  {
+    id: "bob",
+    username: "bob",
+    displayName: "Bob",
+  },
+  {
+    id: "marie",
+    username: "marie",
+    displayName: "Marie",
+  },
+  {
+    id: "john",
+    username: "john",
+    displayName: "John Richards Emperor of long names",
+  },
+]
+
+const firstOwner = sharedWithOne
+const secondOwner = []
+secondOwner[0] = sharedWithTwo[0]
+
+const indicators = [
+  {
+    id: "files-sharing",
+    label: "Shared with other people",
+    visible: true,
+    icon: "group",
+    handler: (resource, indicatorId) =>
+      alert(`Resource: ${resource.name}, indicator: ${indicatorId}`),
+  },
+  {
+    id: "file-link",
+    label: "Shared via link",
+    visible: true,
+    icon: "link",
+  },
+]
+
+const resourcesWithAllFields = [
+  {
+    id: "forest",
+    name: "forest.jpg",
+    path: "images/nature/forest.jpg",
+    thumbnail: "https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg",
+    indicators,
+    type: "file",
+    size: "111000234",
+    mdate: mdate1,
+    sdate: sdate1,
+    ddate: ddate1,
+    owner: firstOwner,
+    sharedWith: sharedWithOne,
+  },
+  {
+    id: "notes",
+    name: "notes.txt",
+    path: "/Documents/notes.txt",
+    icon: "text",
+    indicators,
+    type: "file",
+    size: "1245",
+    mdate: mdate2,
+    sdate: sdate2,
+    ddate: ddate2,
+    owner: secondOwner,
+    sharedWith: sharedWithTwo,
+  },
+  {
+    id: "documents",
+    name: "Documents",
+    path: "/Documents",
+    icon: "folder",
+    indicators,
+    type: "folder",
+    size: "5324435",
+    mdate: mdate3,
+    sdate: sdate3,
+    ddate: ddate3,
+    owner: firstOwner,
+    sharedWith: sharedWithThree,
+  },
+]
+
+describe("OcTableFiles.sort", () => {
+  const wrapper = mount(Table, {
+    propsData: {
+      resources: resourcesWithAllFields,
+    },
+  })
+
+  const headers = wrapper.findAll("thead th")
+
+  // headers.at(0) is the selection checkbox
+  const sortByName = headers.at(1)
+  const sortBySize = headers.at(2)
+  const sortBySharedWith = headers.at(3)
+  const sortByOwner = headers.at(4)
+  const sortByMdate = headers.at(5)
+
+  it("renders all sorting table headers correctly", () => {
+    expect(wrapper.findAll("[aria-sort]").length).toBe(7)
+  })
+
+  it("displays all fields in initial order", () => {
+    let resources = wrapper.findAll(".oc-resource-name")
+
+    expect(resources.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resources.at(1).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resources.at(2).attributes("data-test-resource-name")).toBe("Documents")
+  })
+
+  it("sorts by name", async () => {
+    expect(sortByName.attributes("aria-sort")).toBe(NONE)
+    expect(sortBySize.attributes("aria-sort")).toBe(NONE)
+
+    await sortByName.trigger("click")
+
+    expect(sortByName.attributes("aria-sort")).toBe(DESC)
+    expect(sortBySize.attributes("aria-sort")).toBe(NONE)
+
+    let resourcesOne = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("notes.txt")
+
+    await sortByName.trigger("click")
+
+    expect(sortByName.attributes("aria-sort")).toBe(ASC)
+
+    let resourcesTwo = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("Documents")
+  })
+
+  it("sorts by size", async () => {
+    expect(sortByName.attributes("aria-sort")).toBe(ASC)
+    expect(sortBySize.attributes("aria-sort")).toBe(NONE)
+
+    await sortBySize.trigger("click")
+
+    expect(sortByName.attributes("aria-sort")).toBe(NONE)
+    expect(sortBySize.attributes("aria-sort")).toBe(ASC)
+
+    let resourcesOne = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("notes.txt")
+
+    await sortBySize.trigger("click")
+
+    expect(sortBySize.attributes("aria-sort")).toBe(DESC)
+
+    let resourcesTwo = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("forest.jpg")
+  })
+
+  it("sorts by modification date", async () => {
+    expect(sortByMdate.attributes("aria-sort")).toBe(NONE)
+    expect(sortBySize.attributes("aria-sort")).toBe(DESC)
+
+    await sortByMdate.trigger("click")
+
+    expect(sortByMdate.attributes("aria-sort")).toBe(DESC)
+    expect(sortBySize.attributes("aria-sort")).toBe(NONE)
+
+    let resourcesOne = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("notes.txt")
+
+    await sortByMdate.trigger("click")
+
+    expect(sortByMdate.attributes("aria-sort")).toBe(ASC)
+
+    let resourcesTwo = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("forest.jpg")
+  })
+
+  it("sorts by owner", async () => {
+    expect(sortByOwner.attributes("aria-sort")).toBe(NONE)
+    expect(sortByMdate.attributes("aria-sort")).toBe(ASC)
+
+    await sortByOwner.trigger("click")
+
+    expect(sortByOwner.attributes("aria-sort")).toBe(ASC)
+    expect(sortByMdate.attributes("aria-sort")).toBe(NONE)
+
+    let resourcesOne = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("Documents")
+
+    await sortByOwner.trigger("click")
+
+    expect(sortByOwner.attributes("aria-sort")).toBe(DESC)
+
+    let resourcesTwo = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("notes.txt")
+  })
+
+  it("sorts by shares", async () => {
+    expect(sortBySharedWith.attributes("aria-sort")).toBe(NONE)
+    expect(sortByOwner.attributes("aria-sort")).toBe(DESC)
+
+    await sortBySharedWith.trigger("click")
+
+    expect(sortBySharedWith.attributes("aria-sort")).toBe(DESC)
+    expect(sortByOwner.attributes("aria-sort")).toBe(NONE)
+
+    let resourcesOne = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("Documents")
+
+    await sortBySharedWith.trigger("click")
+
+    expect(sortBySharedWith.attributes("aria-sort")).toBe(ASC)
+
+    let resourcesTwo = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("forest.jpg")
+  })
+})

--- a/src/components/table/mixins/sort.js
+++ b/src/components/table/mixins/sort.js
@@ -28,11 +28,7 @@ export default {
         const { sortable } = this.fields.find(f => f.name === this.sortBy)
 
         if (sortable) {
-          if (
-            typeof sortable === "string" &&
-            Array.isArray.call(aValue) &&
-            Array.isArray.call(bValue)
-          ) {
+          if (typeof sortable === "string") {
             const genArrComp = vals => {
               return vals.map(val => val[sortable]).join("")
             }

--- a/src/components/table/mixins/sort.js
+++ b/src/components/table/mixins/sort.js
@@ -21,9 +21,29 @@ export default {
       }
 
       return [...this.data].sort((a, b) => {
-        const aValue = a[this.sortBy]
-        const bValue = b[this.sortBy]
+        let aValue = a[this.sortBy]
+        let bValue = b[this.sortBy]
         const modifier = this.sortDir === SORT_DIRECTION_ASC ? 1 : -1
+
+        const { sortable } = this.fields.find(f => f.name === this.sortBy)
+
+        if (sortable) {
+          if (
+            typeof sortable === "string" &&
+            Array.isArray.call(aValue) &&
+            Array.isArray.call(bValue)
+          ) {
+            const genArrComp = vals => {
+              return vals.map(val => val[sortable]).join("")
+            }
+
+            aValue = genArrComp(aValue)
+            bValue = genArrComp(bValue)
+          } else if (typeof sortable === "function") {
+            aValue = sortable(aValue)
+            bValue = sortable(bValue)
+          }
+        }
 
         if (!isNaN(aValue) && !isNaN(bValue)) {
           return (aValue - bValue) * modifier


### PR DESCRIPTION
## Description
Currently, same sized arrays containing objects don't get properly sorted. We've added the capability to sort them based on their keys by passing a string or function

## Related Issue
- Fixes #1370

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] Code changes

## Open tasks:
- [X] Unit tests added
