### PR TITLE
Add max-width and max-height vars for OcLogo and increase defaults

### DIFF
--- a/changelog/unreleased/enhancement-logo-sizing
+++ b/changelog/unreleased/enhancement-logo-sizing
@@ -1,0 +1,7 @@
+Enhancement: Logo sizing
+
+We've added theming variables for the max-width and max-height of the OcLogo component and increased the default (max-)height.
+
+https://github.com/owncloud/owncloud-design-system/issues/795
+https://github.com/owncloud/web/issues/5128
+https://github.com/owncloud/owncloud-design-system/pull/1380

--- a/src/components/OcLogo.vue
+++ b/src/components/OcLogo.vue
@@ -38,7 +38,8 @@ export default {
 
 <style lang="scss">
 .oc-logo {
-  height: var(--oc-size-height-small);
+  max-width: var(--oc-size-max-width-logo);
+  max-height: var(--oc-size-max-height-logo);
   margin: var(--oc-space-small);
 }
 </style>

--- a/src/tokens/ods/size.yaml
+++ b/src/tokens/ods/size.yaml
@@ -1,5 +1,11 @@
 ---
 size:
+  max-width:
+    logo:
+      value: 150px
+  max-height:
+    logo:
+      value: 65px
   height:
     small:
       value: 50px


### PR DESCRIPTION
## Description
We've added theming variables for the max-width and max-height of the OcLogo component and increased the default (max-)height.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/owncloud-design-system/issues/795

## Screenshots
This will change the sidebar in ownCloud Web from this:
<img width="301" alt="Screenshot 2021-06-12 at 00 04 16" src="https://user-images.githubusercontent.com/3532843/121753063-ce3e3d00-cb11-11eb-94b7-37ddf2ef981b.png">

to this:
<img width="301" alt="Screenshot 2021-06-12 at 00 04 10" src="https://user-images.githubusercontent.com/3532843/121753071-d39b8780-cb11-11eb-9f78-b6ad9a81f0c2.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
