### PR TITLE
Add breakpoints to theming initialization

### DIFF
--- a/changelog/unreleased/enhancement-add-breakpoints-to-theming-init
+++ b/changelog/unreleased/enhancement-add-breakpoints-to-theming-init
@@ -1,0 +1,7 @@
+Enhancement: Theme-able breakpoint variables
+
+We've added custom CSS props for breakpoints a while ago but missed adding them to the theming initialization, 
+so they weren't theme-able until now.
+
+https://github.com/owncloud/web/pull/5281
+https://github.com/owncloud/owncloud-design-system/pull/1388

--- a/src/system.js
+++ b/src/system.js
@@ -21,6 +21,7 @@ const initializeCustomProps = (tokens = [], prefix) => {
 const System = {
   install(Vue, options = {}) {
     const themeOptions = options.tokens
+    initializeCustomProps(themeOptions?.breakpoints, "breakpoint-")
     initializeCustomProps(themeOptions?.colorPalette, "color-")
     initializeCustomProps(themeOptions?.fontSizes, "font-size-")
     initializeCustomProps(themeOptions?.sizes, "size-")

--- a/src/system.spec.js
+++ b/src/system.spec.js
@@ -3,6 +3,9 @@ import DesignSystem from "./system"
 
 let options = {
   tokens: {
+    breakpoints: {
+      "xsmall-max": "50px"
+    },
     colorPalette: {
       "background-default": "#ef23ab",
       "swatch-brand-default": "#00FFFF",    
@@ -23,6 +26,7 @@ Vue.use(DesignSystem, options)
 
 describe("Depending on what gets passed into the theming options", () => {
   it('Sets correct custom CSS props from theming options', () => {
+    expect(document.documentElement.style.getPropertyValue('--oc-breakpoint-xsmall-max')).toMatch('50px')
     expect(document.documentElement.style.getPropertyValue('--oc-color-background-default')).toMatch('#ef23ab')
     expect(document.documentElement.style.getPropertyValue('--oc-color-swatch-brand-default')).toMatch('#00FFFF')
     expect(document.documentElement.style.getPropertyValue('--oc-font-size-default')).toMatch('1.358rem')


### PR DESCRIPTION
## Description
Technically a bugfix but since we haven't communicated the theme-ability of breakpoints it can count as a feature 👹 

## Motivation and Context
We have breakpoint CSS props and the ability to set custom CSS props via theming but were missing out on initializing (possibly present) breakpoint variables from a theming config passed by a ODS user