### PR TITLE
show '--' for negative file size

### DIFF
--- a/changelog/unreleased/bugfix-show-dashes-when-negative-filesize-given
+++ b/changelog/unreleased/bugfix-show-dashes-when-negative-filesize-given
@@ -1,0 +1,6 @@
+Bugfix: show `--` as file-size when the folder size is not yet computed
+
+When the folder size is unknown (not yet calculated or cannot be calculated) the server returns `-1` as the size. In this case we now show `--` and not only an empty string
+
+https://github.com/owncloud/owncloud-design-system/issues/1402
+https://github.com/owncloud/owncloud-design-system/pull/1393

--- a/src/components/resource/OcResourceSize.spec.js
+++ b/src/components/resource/OcResourceSize.spec.js
@@ -10,7 +10,7 @@ describe("OcResourceSize", () => {
       },
     })
 
-    expect(wrapper.find(".oc-resource-size").text()).toMatch("?")
+    expect(wrapper.find(".oc-resource-size").text()).toEqual("?")
   })
 
   it("shows an empty string for values smaller than 0", () => {
@@ -20,7 +20,7 @@ describe("OcResourceSize", () => {
       },
     })
 
-    expect(wrapper.find(".oc-resource-size").text()).toMatch("")
+    expect(wrapper.find(".oc-resource-size").text()).toEqual("")
   })
 
   it("shows reasonable decimal places", async () => {
@@ -29,13 +29,13 @@ describe("OcResourceSize", () => {
         size: 24064,
       },
     })
-    expect(wrapper.find(".oc-resource-size").text()).toMatch("24 KB")
+    expect(wrapper.find(".oc-resource-size").text()).toEqual("24 KB")
 
     wrapper.setProps({
       size: 44145049,
     })
     await wrapper.vm.$nextTick()
-    expect(wrapper.find(".oc-resource-size").text()).toMatch("42.1 MB")
+    expect(wrapper.find(".oc-resource-size").text()).toEqual("42.1 MB")
   })
 
   it("converts strings to numbers", () => {
@@ -44,7 +44,7 @@ describe("OcResourceSize", () => {
         size: "24064",
       },
     })
-    expect(wrapper.find(".oc-resource-size").text()).toMatch("24 KB")
+    expect(wrapper.find(".oc-resource-size").text()).toEqual("24 KB")
   })
 
   describe("language is not defined", () => {

--- a/src/components/resource/OcResourceSize.spec.js
+++ b/src/components/resource/OcResourceSize.spec.js
@@ -13,14 +13,14 @@ describe("OcResourceSize", () => {
     expect(wrapper.find(".oc-resource-size").text()).toEqual("?")
   })
 
-  it("shows an empty string for values smaller than 0", () => {
+  it("shows '--' for values smaller than 0", () => {
     const wrapper = shallowMount(Size, {
       propsData: {
         size: -42,
       },
     })
 
-    expect(wrapper.find(".oc-resource-size").text()).toEqual("")
+    expect(wrapper.find(".oc-resource-size").text()).toEqual("--")
   })
 
   it("shows reasonable decimal places", async () => {

--- a/src/components/resource/OcResourceSize.vue
+++ b/src/components/resource/OcResourceSize.vue
@@ -31,7 +31,7 @@ export default {
       }
 
       if (this.size < 0) {
-        return ""
+        return "--"
       }
 
       const mb = 1048576

--- a/src/components/table/OcTableFiles.spec.js
+++ b/src/components/table/OcTableFiles.spec.js
@@ -141,7 +141,7 @@ describe("OcTableFiles", () => {
 
   it("formats the resource size", () => {
     expect(wrapper.find(".oc-tbody-tr-forest .oc-table-data-cell-size").text()).toEqual("105.9 MB")
-    expect(wrapper.find(".oc-tbody-tr-documents .oc-table-data-cell-size").text()).toEqual("")
+    expect(wrapper.find(".oc-tbody-tr-documents .oc-table-data-cell-size").text()).toEqual("--")
     expect(wrapper.find(".oc-tbody-tr-notes .oc-table-data-cell-size").text()).toEqual("?")
   })
 


### PR DESCRIPTION
## Description
1. use toEqual to assert content, because `toMatch` is expecting a regex, to `toMatch("")` would always be true, I noticed it after I changed the code and the test still passed
2. as discussed in #1402 show negative number as `--` and not empty string


## How Has This Been Tested?
unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix, fixes #1402
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
