### PR TITLE
[tests-only] don't count spec files into the coverage

### DIFF
--- a/jest.conf.js
+++ b/jest.conf.js
@@ -20,11 +20,11 @@ module.exports = {
   collectCoverageFrom: [
     "<rootDir>/src/components/**/*.vue",
     "<rootDir>/src/utils/**/*.{js,vue}",
+    "<rootDir>/src/system.js",
     "<rootDir>/docs/**/*.{js,vue}",
     "!<rootDir>/src/main.js",
     "!<rootDir>/src/router/index.js",
     "!<rootDir>/node_modules/**",
-    "!<rootDir>/src/system.js",
     "!<rootDir>/docs/docs.helper.js",
     "!<rootDir>/docs/components/status/*",
     "!<rootDir>/docs/components/Preview.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,4 +32,4 @@ sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 
 # Exclude files
-sonar.exclusions=build/**,docs/**,node_modules/**,**/tests/**,dist/**,changelog/**,config/**,release/**,package.json,jest.conf.js,jest.setup.js,Makefile,CHANGELOG.md,README.md
+sonar.exclusions=build/**,docs/**,node_modules/**,**/*.spec.js,dist/**,changelog/**,config/**,release/**,package.json,jest.conf.js,jest.setup.js,Makefile,CHANGELOG.md,README.md


### PR DESCRIPTION
## Description
spec files don't need to be covered in tests 

## Related Issue
part of https://github.com/owncloud/web/issues/5234

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
correct coverage report

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
look at sonarcloud output

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
