### PR TITLE
ocPagination skip label bugfix

### DIFF
--- a/changelog/unreleased/bugfix-pagination-unnecessary-skip
+++ b/changelog/unreleased/bugfix-pagination-unnecessary-skip
@@ -5,4 +5,4 @@ and 4 are available, it rendered a skip label `< 1 2 ... 4 >` even if it's not r
 
 Now this is fixed and it renders `< 1 2 3 4 >` instead.
 
-https://github.com/owncloud/owncloud-design-system/pull/1404
+https://github.com/owncloud/owncloud-design-system/pull/1406

--- a/changelog/unreleased/bugfix-pagination-unnecessary-skip
+++ b/changelog/unreleased/bugfix-pagination-unnecessary-skip
@@ -1,0 +1,8 @@
+Bugfix: Pagination renders unnecessary ... skip label
+
+In cases where the pagination should only render 4 pages at once
+and 4 are available, it rendered a skip label `< 1 2 ... 4 >` even if it's not required.
+
+Now this is fixed and it renders `< 1 2 3 4 >` instead.
+
+https://github.com/owncloud/owncloud-design-system/pull/1404

--- a/src/components/pagination/OcPagination.spec.js
+++ b/src/components/pagination/OcPagination.spec.js
@@ -66,6 +66,39 @@ describe("OcPagination", () => {
     expect(wrapper.findAll(".oc-pagination-list-item-current").length).toBe(1)
   })
 
+  it("does not truncates pages if length of pages is the same as with ...", async () => {
+    const wrapper = shallowMount(Pagination, {
+      propsData: {
+        ...defaultProps,
+        pages: 4,
+        currentPage: 1,
+        maxDisplayed: 3,
+      },
+    })
+
+    expect(wrapper.find(".oc-pagination-list-item-ellipsis").exists()).toBeFalsy()
+    expect(wrapper.find(".oc-pagination-list-item-prev").exists()).toBeFalsy()
+    expect(wrapper.find(".oc-pagination-list-item-next").exists()).toBeTruthy()
+
+    wrapper.setProps({ currentPage: 2 })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find(".oc-pagination-list-item-ellipsis").exists()).toBeFalsy()
+    expect(wrapper.find(".oc-pagination-list-item-prev").exists()).toBeTruthy()
+    expect(wrapper.find(".oc-pagination-list-item-next").exists()).toBeTruthy()
+
+    wrapper.setProps({ currentPage: 4 })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find(".oc-pagination-list-item-ellipsis").exists()).toBeFalsy()
+    expect(wrapper.find(".oc-pagination-list-item-prev").exists()).toBeTruthy()
+    expect(wrapper.find(".oc-pagination-list-item-next").exists()).toBeFalsy()
+
+    wrapper.setProps({ pages: 10 })
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find(".oc-pagination-list-item-ellipsis").exists()).toBeTruthy()
+  })
+
   it("doesn't show ellipsis if maxDisplayed prop is set but no pages are removed", () => {
     const wrapper = shallowMount(Pagination, {
       propsData: {

--- a/src/components/pagination/OcPagination.vue
+++ b/src/components/pagination/OcPagination.vue
@@ -93,7 +93,7 @@ export default {
         pages.push(i + 1)
       }
 
-      if (this.maxDisplayed && this.maxDisplayed < this.pages) {
+      if (this.maxDisplayed && this.maxDisplayed + 1 < this.pages) {
         const currentPageIndex = this.$_currentPage - 1
         const indentation = Math.floor(this.maxDisplayed / 2)
 


### PR DESCRIPTION
## Description
In cases where the pagination should only render 4 pages at once
and 4 are available, it rendered a skip label `< 1 2 ... 4 >` even if it's not required.

Now this is fixed and it renders `< 1 2 3 4 >` instead.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/owncloud-design-system/issues/1404

## Motivation and Context
the pagination should render the pool of available items correctly

## How Has This Been Tested?
local installation

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
- [X] reproduce and fix #1405 > fixed in #1407
