### PR TITLE
fix oc-icon name update error

### DIFF
--- a/changelog/unreleased/bugfix-icon-update
+++ b/changelog/unreleased/bugfix-icon-update
@@ -1,0 +1,9 @@
+Bugfix: OcIcon crashes if icon gets updated
+
+before this bugfix, updating `oc-icon` name prop crashed `vue-inline-svg`.
+We had to overwrite `vue-inline-svg` download method and forgot to implement its `isPending`
+property on the returned promise.
+
+This is fixed now and tested
+
+https://github.com/owncloud/owncloud-design-system/pull/1407

--- a/src/components/OcIcon.spec.js
+++ b/src/components/OcIcon.spec.js
@@ -1,0 +1,32 @@
+import { mount } from "@vue/test-utils"
+import OcIcon from "./OcIcon.vue"
+import glob from "glob"
+import path from "path"
+
+describe("OcIcon", () => {
+  test("render and update", async () => {
+    const icons = glob.sync(path.resolve(__dirname, "..", "assets", "icons", "*.svg")).map(p => ({
+      name: path.basename(p, ".svg"),
+      path: path.relative(__dirname, p),
+    }))
+
+    for (const icon of icons) {
+      jest.doMock(icon.path, () => {
+        return `<svg><text>${icon.name}</text></svg>`
+      })
+    }
+
+    const wrapper = mount(OcIcon)
+    await wrapper.vm.$nextTick()
+    const inlineSvg = wrapper.findComponent({ name: "inline-svg" })
+
+    for (const icon of icons) {
+      wrapper.setProps({ name: icon.name })
+      await wrapper.vm.$nextTick()
+      await inlineSvg.emitted("unloaded")
+      await inlineSvg.emitted("loaded")
+      expect(wrapper.find("text").text()).toBe(icon.name)
+      jest.unmock(icon.path)
+    }
+  })
+})


### PR DESCRIPTION
## Description
Updating `oc-icon` name prop crashed `vue-inline-svg`.
We had to overwrite `vue-inline-svg` download method and forgot to implement its `isPending`
property on the returned promise.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #1405

## Motivation and Context
be able to update icons

## How Has This Been Tested?
- local installation with setTimeout

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests

## Checklist:
- [X] Code changes
- [X] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
