### PR TITLE
[unit-tests] Added unit tests for oc app sidebar

### DIFF
--- a/src/components/OcAppSideBar.spec.js
+++ b/src/components/OcAppSideBar.spec.js
@@ -1,0 +1,65 @@
+import { mount } from "@vue/test-utils"
+import OcAppSideBar from "./OcAppSideBar.vue"
+
+describe("OcAppSideBar", () => {
+  const selectors = {
+    sideBar: ".oc-app-side-bar",
+    title: ".sidebar-title",
+    content: ".content",
+    footer: ".footer",
+    action: ".action",
+  }
+  function getWrapper(props = {}, slots = {}) {
+    return mount(OcAppSideBar, {
+      propsData: {
+        ...props,
+      },
+      slots: {
+        ...slots,
+      },
+    })
+  }
+  describe("sidebar title", () => {
+    it("should set the provided heading text from prop", () => {
+      const wrapper = getWrapper({
+        headingText: "Test Heading",
+      })
+      expect(wrapper.find(selectors.title).exists()).toBeTruthy()
+      expect(wrapper.find(`${selectors.title} span`).text()).toBe("Test Heading")
+    })
+  })
+  describe("sidebar slots", () => {
+    it.each`
+      slot
+      ${"title"}
+      ${"content"}
+      ${"footer"}
+      ${"action"}
+    `("should content html from content slot $slot", ({ slot }) => {
+      const slotData = {}
+      slotData[slot] = "<p class='test-class'>Lorem ipsum</p>"
+      const wrapper = getWrapper({}, slotData)
+      const sideBarTitleElement = wrapper.find(selectors[slot])
+      expect(sideBarTitleElement.exists()).toBeTruthy()
+      expect(wrapper.find("p").attributes("class")).toBe("test-class")
+      expect(wrapper.find("p").text()).toBe("Lorem ipsum")
+    })
+  })
+  describe("default action", () => {
+    it("should set the provided close button label", () => {
+      const wrapper = getWrapper({
+        closeButtonLabel: "Terminate",
+      })
+      const actionElement = wrapper.find(selectors.action)
+      expect(actionElement.exists()).toBeTruthy()
+      expect(actionElement.find("button").exists()).toBeTruthy()
+      expect(actionElement.find("button").attributes("aria-label")).toBe("Terminate")
+    })
+    it("should emit close when action button is clicked", () => {
+      const wrapper = getWrapper()
+      const actionElement = wrapper.find(selectors.action)
+      actionElement.find("button").trigger("click")
+      expect(wrapper.emitted("close")).toBeTruthy()
+    })
+  })
+})

--- a/src/components/OcAppSideBar.vue
+++ b/src/components/OcAppSideBar.vue
@@ -28,10 +28,17 @@
  * Create a sidebar with title, content and footer that includes a close button
  * in the corner.
  */
+import OcIcon from "./OcIcon.vue"
+import OcButton from "./OcButton.vue"
+
 export default {
   name: "OcAppSideBar",
   status: "ready",
   release: "1.0.0",
+  components: {
+    OcButton,
+    OcIcon,
+  },
   props: {
     disableAction: {
       default: false,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the issue tracker for the design system. 

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of the ownCloud design system.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Assignment: assign to self
-->

## Description
Added unit tests for `OcAppSideBar`
- sidebar title
  ✓ should set the provided heading text from prop
- sidebar slots
  ✓ should content HTML from content slot title
  ✓ should content HTML from content slot content
  ✓ should content HTML from content slot footer
  ✓ should content HTML from content slot action
- default action
  ✓ should set the provided close button label
  ✓ should emit close when the action button is clicked


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #1366  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
