### PR TITLE
added unit tests for OcAutocomplete component

### DIFF
--- a/src/components/OcAutocomplete.spec.js
+++ b/src/components/OcAutocomplete.spec.js
@@ -1,0 +1,80 @@
+import OcAutocomplete from "./OcAutocomplete.vue"
+import { mount } from "@vue/test-utils"
+
+describe("OcAutocomplete", () => {
+  function getWrapperWithProps(props = {}) {
+    return mount(OcAutocomplete, {
+      propsData: {
+        ...props,
+        label: "Test Label",
+      },
+    })
+  }
+  const selectors = {
+    autocomplete: ".oc-autocomplete",
+    message: ".oc-autocomplete-message",
+    dropdown: ".oc-autocomplete-dropdown",
+  }
+  describe("when prop 'inputId' value is provided", () => {
+    it("should set id of input", () => {
+      const wrapper = getWrapperWithProps({ inputId: "test-id" })
+      const inputElement = wrapper.find(`${selectors.autocomplete} input`)
+      expect(inputElement.exists()).toBeTruthy()
+      expect(inputElement.attributes("id")).toBe("test-id")
+    })
+  })
+  describe("label", () => {
+    it("should be target for the autocomplete input", () => {
+      const wrapper = getWrapperWithProps({ inputId: "test-id" })
+      const labelElement = wrapper.find(`${selectors.autocomplete} label`)
+      expect(labelElement.exists()).toBeTruthy()
+      expect(labelElement.attributes("for")).toBe("test-id")
+      expect(labelElement.text()).toBe("Test Label")
+    })
+  })
+  describe("message", () => {
+    describe("when all message props are null", () => {
+      const wrapper = getWrapperWithProps()
+      it("should not render error message", () => {
+        const messageElement = wrapper.find(selectors.message)
+        expect(messageElement.exists()).toBeFalsy()
+      })
+      it("input should not have danger and warning class", () => {
+        const inputElement = wrapper.find(`${selectors.autocomplete} input`)
+        expect(inputElement.attributes("class")).not.toContain("oc-autocomplete-danger")
+        expect(inputElement.attributes("class")).not.toContain("oc-autocomplete-warning")
+      })
+    })
+    describe("description message", () => {
+      it("should render message if prop 'descriptionMessage' is set", () => {
+        const wrapper = getWrapperWithProps({ descriptionMessage: "Help Text" })
+        const descriptionMessageElement = wrapper.find(selectors.message)
+        expect(descriptionMessageElement.exists()).toBeTruthy()
+        expect(descriptionMessageElement.isVisible()).toBeTruthy()
+        expect(descriptionMessageElement.text()).toBe("Help Text")
+      })
+    })
+    describe("warning message & error message", () => {
+      describe.each`
+        prop                | expectedClass
+        ${"errorMessage"}   | ${"oc-autocomplete-danger"}
+        ${"warningMessage"} | ${"oc-autocomplete-warning"}
+      `("when prop '$prop' value is not null", ({ prop, expectedClass }) => {
+        let propsData = {}
+        propsData[prop] = "test message"
+        const wrapper = getWrapperWithProps(propsData)
+        it(`should display the provided prop ${prop} value as message`, () => {
+          const warningMessageElement = wrapper.find(selectors.message)
+          expect(warningMessageElement.exists()).toBeTruthy()
+          expect(warningMessageElement.isVisible()).toBeTruthy()
+          expect(warningMessageElement.text()).toBe("test message")
+          expect(warningMessageElement.get("span").attributes("class")).toContain(expectedClass)
+        })
+        it("input should have respective class", () => {
+          const inputElement = wrapper.find(`${selectors.autocomplete} input`)
+          expect(inputElement.attributes("class")).toContain(expectedClass)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the issue tracker for the design system. 

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of the ownCloud design system.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Assignment: assign to self
-->

## Description
added unit test for `OcAutocomplete` component
- only covered message part
- dropdown test will be added after UiKit removal

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of #1366 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 🤖 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
