### PR TITLE
Handle initial focus in OcModal

### DIFF
--- a/changelog/unreleased/enhancement-modal-initial-focus
+++ b/changelog/unreleased/enhancement-modal-initial-focus
@@ -1,0 +1,6 @@
+Enhancement: Initial focus in OcModal
+
+The OcModal component sets the initial focus to the input element now, if one exists. If the input element doesn't exist the focus remains on the modal itself, like we had it before.
+
+https://github.com/owncloud/owncloud-design-system/pull/1453
+https://github.com/owncloud/web/issues/3684

--- a/src/components/OcModal.vue
+++ b/src/components/OcModal.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="oc-modal-background" aria-labelledby="oc-modal-title">
-    <focus-trap :active="focusTrapActive">
+    <focus-trap :active="true" :initial-focus="getInitialFocusRef">
       <div
-        ref="$_ocModal"
+        ref="ocModal"
         :class="classes"
         tabindex="0"
         role="dialog"
@@ -241,14 +241,6 @@ export default {
       required: false,
       default: false,
     },
-    /**
-     * Asserts whether the modal should be protected with focus trap
-     */
-    focusTrapActive: {
-      type: Boolean,
-      required: false,
-      default: false,
-    },
   },
   data() {
     return {
@@ -265,11 +257,6 @@ export default {
       handler: "inputAssignPropAsValue",
       immediate: true,
     },
-  },
-  mounted() {
-    this.$nextTick(() => {
-      this.$refs.$_ocModal.focus()
-    })
   },
   methods: {
     cancelModalAction() {
@@ -299,6 +286,12 @@ export default {
     },
     inputAssignPropAsValue(value) {
       this.userInputValue = value
+    },
+    getInitialFocusRef() {
+      if (this.hasInput) {
+        return this.$refs.ocModalInput
+      }
+      return this.$refs.ocModal
     },
   },
 }

--- a/src/components/__snapshots__/OcModal.spec.js.snap
+++ b/src/components/__snapshots__/OcModal.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`OcModal displays input 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->
@@ -22,7 +22,7 @@ exports[`OcModal displays input 1`] = `
 
 exports[`OcModal hides icon if not specified 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->
@@ -42,7 +42,7 @@ exports[`OcModal hides icon if not specified 1`] = `
 
 exports[`OcModal matches snapshot 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <oc-icon-stub name="info" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
@@ -62,7 +62,7 @@ exports[`OcModal matches snapshot 1`] = `
 
 exports[`OcModal overrides props message with slot 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->


### PR DESCRIPTION
## Description
The OcModal component sets the initial focus to the input element now, if one exists. If the input element doesn't exist the focus remains on the modal itself, like we had it before.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/3684

## Motivation and Context
Improve UX

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
