### PR TITLE
Add `comment` icon

### DIFF
--- a/src/assets/icons/comment.svg
+++ b/src/assets/icons/comment.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M21.99 4c0-1.1-.89-2-1.99-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4-.01-18z"/>
+</svg>


### PR DESCRIPTION
Add `comment` icon to icon assets
Coming from google material design. License is apache 2.0, so no attribution is required.
https://fonts.google.com/icons?selected=Material+Icons:mode_comment