### PR TITLE
No hover on current page's breadcrumb item

### DIFF
--- a/changelog/unreleased/bugfix-current-breadcrumb-hover
+++ b/changelog/unreleased/bugfix-current-breadcrumb-hover
@@ -1,0 +1,6 @@
+Bugfix: No hover on current breadcrumb item
+
+The current page's breadcrumb item is not interactive and shouldn't have a focus on hover, so we removed it.
+
+https://github.com/owncloud/owncloud-design-system/issues/1416
+https://github.com/owncloud/owncloud-design-system/pull/1511

--- a/src/components/OcBreadcrumb.vue
+++ b/src/components/OcBreadcrumb.vue
@@ -143,7 +143,7 @@ export default {
     }
 
     > li a:hover,
-    > li span:hover,
+    > li span:not([aria-current="page"]):hover,
     > li button:hover {
       color: var(--oc-color-swatch-primary-default);
     }


### PR DESCRIPTION
## Description
See changelog item

## Related Issue
- Fixes https://github.com/owncloud/owncloud-design-system/issues/1416

## How Has This Been Tested?
- Manually

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] Code changes
