### PR TITLE
Fix resource ID handling in OcTableFiles contextmenu

### DIFF
--- a/changelog/unreleased/bugfix-tablefiles-id
+++ b/changelog/unreleased/bugfix-tablefiles-id
@@ -1,0 +1,6 @@
+Bugfix: OcTableFiles Contextmenu ID
+
+Handling of `=`s in resource IDs in the OcTableFiles contextmenu was broken and lead to undesired behavior.
+This has been fixed now.
+
+https://github.com/owncloud/owncloud-design-system/pull/1525

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -82,20 +82,20 @@
         <!-- @slot Add quick actions directly next to the `showDetails` button in the actions column -->
         <slot name="quickActions" :resource="item" />
         <oc-button
-          :id="`quick-action-${item.id.replace(/=/, '')}`"
+          :id="`quick-action-${item.id.replace(/=*/, '')}`"
           :aria-label="$gettext('Show quick actions')"
           class="oc-table-files-btn-action-dropdown"
           appearance="raw"
           @click.stop.prevent="
-            resetDropPosition(`quick-action-drop-ref-${item.id.replace(/=/, '')}`, $event)
+            resetDropPosition(`quick-action-drop-ref-${item.id.replace(/=*/, '')}`, $event)
           "
         >
           <oc-icon name="more_vert" />
         </oc-button>
         <oc-drop
-          :ref="`quick-action-drop-ref-${item.id.replace(/=/, '')}`"
-          :drop-id="`quick-action-menu-drop-${item.id.replace(/=/, '')}`"
-          :toggle="`#quick-action-${item.id.replace(/=/, '')}`"
+          :ref="`quick-action-drop-ref-${item.id.replace(/=*/, '')}`"
+          :drop-id="`quick-action-menu-drop-${item.id.replace(/=*/, '')}`"
+          :toggle="`#quick-action-${item.id.replace(/=*/, '')}`"
           mode="click"
           close-on-click
         >


### PR DESCRIPTION
## Description
Regex was wrong and actually unnecessary so it can be removed. Needs to be published for integration in `web`.
