### PR TITLE
Fix replace regex for ids in template of OcTableFiles

### DIFF
--- a/changelog/unreleased/bugfix-tablefiles-id
+++ b/changelog/unreleased/bugfix-tablefiles-id
@@ -4,3 +4,4 @@ Handling of `=`s in resource IDs in the OcTableFiles contextmenu was broken and 
 This has been fixed now.
 
 https://github.com/owncloud/owncloud-design-system/pull/1525
+https://github.com/owncloud/owncloud-design-system/pull/1528

--- a/src/components/table/OcTableFiles.spec.js
+++ b/src/components/table/OcTableFiles.spec.js
@@ -101,6 +101,20 @@ const resourcesWithAllFields = [
     sharedWith,
     owner,
   },
+  {
+    id: "another-one==",
+    name: "Another one",
+    path: "/Another one",
+    icon: "folder",
+    indicators,
+    type: "folder",
+    size: "237895",
+    mdate: getCurrentDate(),
+    sdate: getCurrentDate(),
+    ddate: getCurrentDate(),
+    sharedWith,
+    owner,
+  },
 ]
 
 describe("OcTableFiles", () => {
@@ -193,6 +207,15 @@ describe("OcTableFiles", () => {
       threeDotButton.trigger("click")
       expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
       expect(threeDotButton.emitted().click).toBeTruthy()
+    })
+
+    it("removes invalid chars from item ids for usage in html template", async () => {
+      const contextMenuTriggers = await wrapper.findAll(".oc-table-files-btn-action-dropdown")
+      for (let i = 0; i < contextMenuTriggers.length; i++) {
+        const id = contextMenuTriggers.at(i).attributes().id
+        expect(id).not.toBeUndefined()
+        expect(id).toEqual(expect.not.stringContaining("="))
+      }
     })
   })
 })

--- a/src/components/table/OcTableFiles.spec.js
+++ b/src/components/table/OcTableFiles.spec.js
@@ -120,7 +120,7 @@ describe("OcTableFiles", () => {
     },
   })
 
-  it("displays all fields", () => {
+  it("displays all known fields of the resources", () => {
     for (const field of fields) {
       expect(wrapper.findAll(".oc-table-header-cell-" + field).length).toEqual(1)
       expect(wrapper.findAll(".oc-table-data-cell-" + field).length).toEqual(
@@ -129,60 +129,70 @@ describe("OcTableFiles", () => {
     }
   })
 
-  it("emits showDetails event when clicking on the button in actions column", () => {
-    wrapper.find(".oc-table-data-cell-actions .oc-table-files-btn-show-details").vm.$emit("click")
-
-    expect(wrapper.emitted().showDetails).toBeTruthy()
-  })
-
-  it("emits showDetails event when clicking on the row", async () => {
-    await wrapper.find(".oc-tbody-tr").trigger("click")
-
-    expect(wrapper.emitted().showDetails.length).toEqual(2)
-  })
-
-  it("formats the resource size", () => {
+  it("formats the resource size to a human readable format", () => {
     expect(wrapper.find(".oc-tbody-tr-forest .oc-table-data-cell-size").text()).toEqual("105.9 MB")
     expect(wrapper.find(".oc-tbody-tr-documents .oc-table-data-cell-size").text()).toEqual("--")
     expect(wrapper.find(".oc-tbody-tr-notes .oc-table-data-cell-size").text()).toEqual("?")
   })
 
-  it("selects resources", () => {
-    wrapper.find(".oc-table-files-select-all .oc-checkbox").trigger("click")
-    wrapper.find(".oc-tbody-tr-documents .oc-checkbox").trigger("click")
-    expect(wrapper.emitted().select.length).toBe(2)
-  })
-
-  it("de-selects all resources", () => {
-    const wrapperSelected = mount(Table, {
-      propsData: {
-        resources: resourcesWithAllFields,
-        selection: ["forest", "notes", "documents"],
-      },
+  describe("resource selection", () => {
+    it("adds resources to selection model when clicking on checkboxes", () => {
+      wrapper.find(".oc-table-files-select-all .oc-checkbox").trigger("click")
+      wrapper.find(".oc-tbody-tr-documents .oc-checkbox").trigger("click")
+      expect(wrapper.emitted().select.length).toBe(2)
     })
 
-    wrapperSelected.find(".oc-table-files-select-all .oc-checkbox").trigger("click")
-    expect(wrapperSelected.emitted().select[0][0].length).toBe(0)
+    describe("all rows already selected", () => {
+      it("de-selects all resources upon click on the select-all checkbox", () => {
+        const wrapperSelected = mount(Table, {
+          propsData: {
+            resources: resourcesWithAllFields,
+            selection: resourcesWithAllFields.map(resource => resource.id),
+          },
+        })
+
+        wrapperSelected.find(".oc-table-files-select-all .oc-checkbox").trigger("click")
+        expect(wrapperSelected.emitted().select[0][0].length).toBe(0)
+      })
+    })
   })
 
-  it("emits fileClick", () => {
-    wrapper.find(".oc-tbody-tr-forest .oc-resource-name").trigger("click")
+  describe("resource activation", () => {
+    it("emits fileClick upon clicking on a resource name", () => {
+      wrapper.find(".oc-tbody-tr-forest .oc-resource-name").trigger("click")
 
-    expect(wrapper.emitted().fileClick[0][0].name).toMatch("forest.jpg")
+      expect(wrapper.emitted().fileClick[0][0].name).toMatch("forest.jpg")
+    })
   })
 
-  it("emitting contextmenu-clicked event on table row", async () => {
-    const tableRow = await wrapper.find(".oc-tbody-tr-forest")
-    tableRow.vm.$emit("contextmenuClicked")
-    expect(tableRow.emitted().contextmenuClicked).toBeTruthy()
+  describe("resource details", () => {
+    it("emits showDetails event when clicking on the button in actions column", () => {
+      wrapper.find(".oc-table-data-cell-actions .oc-table-files-btn-show-details").vm.$emit("click")
+
+      expect(wrapper.emitted().showDetails).toBeTruthy()
+    })
+
+    it("emits showDetails event when clicking on the row", async () => {
+      await wrapper.find(".oc-tbody-tr").trigger("click")
+
+      expect(wrapper.emitted().showDetails.length).toEqual(2)
+    })
   })
 
-  it("emitting contextmenu-clicked event on clicking the three-dot icon in table row", async () => {
-    const threeDotButton = await wrapper.find(
-      ".oc-table-data-cell-actions .oc-table-files-btn-action-dropdown"
-    )
-    threeDotButton.trigger("click")
-    expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
-    expect(threeDotButton.emitted().click).toBeTruthy()
+  describe("context menu", () => {
+    it("emits contextmenu-clicked event on table row", async () => {
+      const tableRow = await wrapper.find(".oc-tbody-tr-forest")
+      tableRow.vm.$emit("contextmenuClicked")
+      expect(tableRow.emitted().contextmenuClicked).toBeTruthy()
+    })
+
+    it("emits contextmenu-clicked event on clicking the three-dot icon in table row", async () => {
+      const threeDotButton = await wrapper.find(
+        ".oc-table-data-cell-actions .oc-table-files-btn-action-dropdown"
+      )
+      threeDotButton.trigger("click")
+      expect(spyDisplayPositionedDropdown).toHaveBeenCalledTimes(1)
+      expect(threeDotButton.emitted().click).toBeTruthy()
+    })
   })
 })

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -82,20 +82,20 @@
         <!-- @slot Add quick actions directly next to the `showDetails` button in the actions column -->
         <slot name="quickActions" :resource="item" />
         <oc-button
-          :id="`quick-action-${item.id.replace(/=*/, '')}`"
-          :aria-label="$gettext('Show quick actions')"
+          :id="`context-menu-trigger-${item.id.replace(/=+/, '')}`"
+          :aria-label="$gettext('Show context menu')"
           class="oc-table-files-btn-action-dropdown"
           appearance="raw"
           @click.stop.prevent="
-            resetDropPosition(`quick-action-drop-ref-${item.id.replace(/=*/, '')}`, $event)
+            resetDropPosition(`context-menu-drop-ref-${item.id.replace(/=+/, '')}`, $event)
           "
         >
           <oc-icon name="more_vert" />
         </oc-button>
         <oc-drop
-          :ref="`quick-action-drop-ref-${item.id.replace(/=*/, '')}`"
-          :drop-id="`quick-action-menu-drop-${item.id.replace(/=*/, '')}`"
-          :toggle="`#quick-action-${item.id.replace(/=*/, '')}`"
+          :ref="`context-menu-drop-ref-${item.id.replace(/=+/, '')}`"
+          :drop-id="`context-menu-drop-${item.id.replace(/=+/, '')}`"
+          :toggle="`#context-menu-trigger-${item.id.replace(/=+/, '')}`"
           mode="click"
           close-on-click
         >


### PR DESCRIPTION
## Description
Regex for cleaning up the resource ids being used in the template of OcTableFiles was not greedy (my bad). Fixing it with this PR.
Additionally this PR
- groups unit tests of OcTableFiles so that reading the spec file is (hopefully) easier
- changes html ids to `context-menu` instead of `quick-action`, which IMO is more precise
- changes the aria-label `Show quick actions` to `Show context menu`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- added a unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
