### PR TITLE
Make OcButton inline

### DIFF
--- a/changelog/unreleased/bugfix-button-inline-flex
+++ b/changelog/unreleased/bugfix-button-inline-flex
@@ -1,0 +1,5 @@
+Bugfix: Button as inline element
+
+We made our OcButton an inline-flex instead of a flex element, so that it behaves correctly regarding alignment inside containers.
+
+https://github.com/owncloud/owncloud-design-system/pull/1529

--- a/src/components/OcButton.vue
+++ b/src/components/OcButton.vue
@@ -280,7 +280,7 @@ export default {
   border-radius: 3px;
   box-sizing: border-box;
   color: var(--oc-color-text-inverse);
-  display: flex;
+  display: inline-flex;
   font-weight: 600;
   padding: 0.5rem 0.75rem;
   text-align: center;


### PR DESCRIPTION
## Description
Our OcButton had `display: flex` which basically made it a block element and destroyed alignment of buttons inside containers. This PR changes it to `display: inline-flex` which makes it an inline element again (default display of a button is `inline-block`).

For review: please build locally and test in ownCloud Web with a local link.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
