### PR TITLE
Fix unnecessary showDetails event in OcTableFiles

### DIFF
--- a/changelog/8.3.1_2021-08-04/bugfix-context-menu-events
+++ b/changelog/8.3.1_2021-08-04/bugfix-context-menu-events
@@ -1,0 +1,5 @@
+Bugfix: Unnecessary context menu events
+
+Clicking on the context menu in OcTableFiles was emitting unnecessary showDetails events. This has been fixed.
+
+https://github.com/owncloud/owncloud-design-system/pull/1564

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owncloud-design-system",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "ownCloud Design System is based on VueDesign Systems and is used to design ownCloud UI components",
   "keywords": [
     "vue design system",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 sonar.projectKey=owncloud_owncloud-design-system
 sonar.organization=owncloud-1
 sonar.projectName=owncloud-design-system
-sonar.projectVersion=8.3.0
+sonar.projectVersion=8.3.1
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -98,6 +98,7 @@
           :toggle="`#context-menu-trigger-${item.id.replace(/=+/, '')}`"
           mode="click"
           close-on-click
+          @click.native.stop.prevent
         >
           <!-- @slot Add context actions that open in a dropdown when clicking on the "three dots" button -->
           <slot name="contextMenu" :resource="item" />


### PR DESCRIPTION
## Description
This PR fixes that a click on a context menu item in OcTableFiles also emitted an unnecessary `showDetails` event.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
