### PR TITLE
Fix sorting behaviour

### DIFF
--- a/changelog/unreleased/bugfix-default-sort-by
+++ b/changelog/unreleased/bugfix-default-sort-by
@@ -1,0 +1,5 @@
+Bugfix: Initial sorting for OcTableFiles
+
+The OcTableFiles component didn't apply initial sorting. This was set to the first sortable field in the list of fields (which is "name").
+
+https://github.com/owncloud/owncloud-design-system/pull/1588

--- a/changelog/unreleased/bugfix-sort-by-date
+++ b/changelog/unreleased/bugfix-sort-by-date
@@ -1,0 +1,5 @@
+Bugfix: Sorting by date
+
+The OcTableFiles component sorted rows lexicographically by relative dates (e.g. "1 hour ago"). This was fixed to sort by unix timestamps instead.
+
+https://github.com/owncloud/owncloud-design-system/pull/1588

--- a/changelog/unreleased/bugfix-sort-by-date
+++ b/changelog/unreleased/bugfix-sort-by-date
@@ -2,4 +2,5 @@ Bugfix: Sorting by date
 
 The OcTableFiles component sorted rows lexicographically by relative dates (e.g. "1 hour ago"). This was fixed to sort by unix timestamps instead.
 
+https://github.com/owncloud/owncloud-design-system/issues/1552
 https://github.com/owncloud/owncloud-design-system/pull/1588

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -331,7 +331,7 @@ export default {
             alignH: "right",
             wrap: "nowrap",
             callback: date => this.formatDate(date),
-            sortable: true,
+            sortable: date => this.unixDate(date),
           },
           {
             name: "sdate",
@@ -340,7 +340,7 @@ export default {
             alignH: "right",
             wrap: "nowrap",
             callback: date => this.formatDate(date),
-            sortable: true,
+            sortable: date => this.unixDate(date),
           },
           {
             name: "ddate",
@@ -349,7 +349,7 @@ export default {
             alignH: "right",
             wrap: "nowrap",
             callback: date => this.formatDate(date),
-            sortable: true,
+            sortable: date => this.unixDate(date),
           },
         ].filter(field => Object.prototype.hasOwnProperty.call(firstResource, field.name))
       )
@@ -445,6 +445,9 @@ export default {
     },
     formatDate(date) {
       return DateTime.fromJSDate(new Date(date)).toRelative()
+    },
+    unixDate(date) {
+      return DateTime.fromJSDate(new Date(date)).valueOf()
     },
 
     emitSelect(resources) {

--- a/src/components/table/OcTableFilesSort.spec.js
+++ b/src/components/table/OcTableFilesSort.spec.js
@@ -1,6 +1,7 @@
-import { mount } from "@vue/test-utils"
+import { mount, shallowMount } from "@vue/test-utils"
 
 import Table from "./OcTableFiles.vue"
+import OcButton from "../OcButton"
 
 const ASC = "ascending"
 const DESC = "descending"
@@ -118,92 +119,114 @@ const resourcesWithAllFields = [
 ]
 
 describe("OcTableFiles.sort", () => {
-  const wrapper = mount(Table, {
-    propsData: {
-      resources: resourcesWithAllFields,
-    },
-  })
+  function getWrapperWithProps(props = {}) {
+    return mount(Table, {
+      propsData: {
+        resources: resourcesWithAllFields,
+        ...props,
+      },
+    })
+  }
 
-  const headers = wrapper.findAll("thead th")
+  function getHeaders(wrapper) {
+    return wrapper.findAll("thead th")
+  }
 
-  // headers.at(0) is the selection checkbox
-  const sortByName = headers.at(1)
-  const sortBySize = headers.at(2)
-  const sortBySharedWith = headers.at(3)
-  const sortByOwner = headers.at(4)
-  const sortByMdate = headers.at(5)
+  function getSortByName(wrapper) {
+    return getHeaders(wrapper).at(1)
+  }
+
+  function getSortBySize(wrapper) {
+    return getHeaders(wrapper).at(2)
+  }
+
+  function getSortBySharedWith(wrapper) {
+    return getHeaders(wrapper).at(3)
+  }
+
+  function getSortByOwner(wrapper) {
+    return getHeaders(wrapper).at(4)
+  }
+
+  function getSortByMdate(wrapper) {
+    return getHeaders(wrapper).at(5)
+  }
 
   it("renders all sorting table headers correctly", () => {
-    expect(wrapper.findAll("[aria-sort]").length).toBe(5)
+    expect(getWrapperWithProps().findAll("[aria-sort]").length).toBe(5)
   })
 
-  it("displays all fields in initial order", () => {
-    let resources = wrapper.findAll(".oc-resource-name")
+  it("displays all fields in order of first sortable field", () => {
+    let resources = getWrapperWithProps().findAll(".oc-resource-name")
 
-    expect(resources.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
-    expect(resources.at(1).attributes("data-test-resource-name")).toBe("notes.txt")
-    expect(resources.at(2).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resources.at(0).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resources.at(1).attributes("data-test-resource-name")).toBe("Pdfs")
+    expect(resources.at(2).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resources.at(3).attributes("data-test-resource-name")).toBe("notes.txt")
   })
 
-  it("sorts by name", async () => {
-    expect(sortByName.attributes("aria-sort")).toBe(NONE)
+  it("sorts by name on click", async () => {
+    const wrapper = getWrapperWithProps()
+    const sortByName = getSortByName(wrapper)
+    const sortBySize = getSortBySize(wrapper)
+
+    await sortByName.trigger("click")
+
+    expect(sortByName.attributes("aria-sort")).toBe(ASC)
     expect(sortBySize.attributes("aria-sort")).toBe(NONE)
+
+    let resourcesOne = wrapper.findAll(".oc-resource-name")
+
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("Pdfs")
+    expect(resourcesOne.at(3).attributes("data-test-resource-name")).toBe("Documents")
 
     await sortByName.trigger("click")
 
     expect(sortByName.attributes("aria-sort")).toBe(DESC)
-    expect(sortBySize.attributes("aria-sort")).toBe(NONE)
-
-    let resourcesOne = wrapper.findAll(".oc-resource-name")
-
-    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("Documents")
-    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("Pdfs")
-    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("forest.jpg")
-    expect(resourcesOne.at(3).attributes("data-test-resource-name")).toBe("notes.txt")
-
-    await sortByName.trigger("click")
-
-    expect(sortByName.attributes("aria-sort")).toBe(ASC)
 
     let resourcesTwo = wrapper.findAll(".oc-resource-name")
 
-    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
-    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("forest.jpg")
-    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("Pdfs")
-    expect(resourcesTwo.at(3).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("Pdfs")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesTwo.at(3).attributes("data-test-resource-name")).toBe("notes.txt")
   })
 
   it("sorts by size", async () => {
-    expect(sortByName.attributes("aria-sort")).toBe(ASC)
-    expect(sortBySize.attributes("aria-sort")).toBe(NONE)
+    const wrapper = getWrapperWithProps()
+    const sortByName = getSortByName(wrapper)
+    const sortBySize = getSortBySize(wrapper)
 
     await sortBySize.trigger("click")
 
     expect(sortByName.attributes("aria-sort")).toBe(NONE)
-    expect(sortBySize.attributes("aria-sort")).toBe(ASC)
+    expect(sortBySize.attributes("aria-sort")).toBe(DESC)
 
     let resourcesOne = wrapper.findAll(".oc-resource-name")
 
-    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
-    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("Documents")
-    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("Pdfs")
-    expect(resourcesOne.at(3).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("Pdfs")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesOne.at(3).attributes("data-test-resource-name")).toBe("forest.jpg")
 
     await sortBySize.trigger("click")
 
-    expect(sortBySize.attributes("aria-sort")).toBe(DESC)
+    expect(sortBySize.attributes("aria-sort")).toBe(ASC)
 
     let resourcesTwo = wrapper.findAll(".oc-resource-name")
 
-    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
-    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("Pdfs")
-    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("Documents")
-    expect(resourcesTwo.at(3).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("Pdfs")
+    expect(resourcesTwo.at(3).attributes("data-test-resource-name")).toBe("notes.txt")
   })
 
   it("sorts by modification date", async () => {
-    expect(sortByMdate.attributes("aria-sort")).toBe(NONE)
-    expect(sortBySize.attributes("aria-sort")).toBe(DESC)
+    const wrapper = getWrapperWithProps()
+    const sortByMdate = getSortByMdate(wrapper)
+    const sortBySize = getSortBySize(wrapper)
 
     await sortByMdate.trigger("click")
 
@@ -229,36 +252,38 @@ describe("OcTableFiles.sort", () => {
   })
 
   it("sorts by owner", async () => {
-    expect(sortByOwner.attributes("aria-sort")).toBe(NONE)
-    expect(sortByMdate.attributes("aria-sort")).toBe(ASC)
+    const wrapper = getWrapperWithProps()
+    const sortByMdate = getSortByMdate(wrapper)
+    const sortByOwner = getSortByOwner(wrapper)
 
     await sortByOwner.trigger("click")
 
-    expect(sortByOwner.attributes("aria-sort")).toBe(ASC)
+    expect(sortByOwner.attributes("aria-sort")).toBe(DESC)
     expect(sortByMdate.attributes("aria-sort")).toBe(NONE)
 
     let resourcesOne = wrapper.findAll(".oc-resource-name")
 
-    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
-    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("forest.jpg")
-    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("Documents")
-    expect(resourcesOne.at(3).attributes("data-test-resource-name")).toBe("Pdfs")
+    expect(resourcesOne.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesOne.at(1).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesOne.at(2).attributes("data-test-resource-name")).toBe("Pdfs")
+    expect(resourcesOne.at(3).attributes("data-test-resource-name")).toBe("notes.txt")
 
     await sortByOwner.trigger("click")
 
-    expect(sortByOwner.attributes("aria-sort")).toBe(DESC)
+    expect(sortByOwner.attributes("aria-sort")).toBe(ASC)
 
     let resourcesTwo = wrapper.findAll(".oc-resource-name")
 
-    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("forest.jpg")
-    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("Documents")
-    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("Pdfs")
-    expect(resourcesTwo.at(3).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesTwo.at(0).attributes("data-test-resource-name")).toBe("notes.txt")
+    expect(resourcesTwo.at(1).attributes("data-test-resource-name")).toBe("forest.jpg")
+    expect(resourcesTwo.at(2).attributes("data-test-resource-name")).toBe("Documents")
+    expect(resourcesTwo.at(3).attributes("data-test-resource-name")).toBe("Pdfs")
   })
 
   it("sorts by shares", async () => {
-    expect(sortBySharedWith.attributes("aria-sort")).toBe(NONE)
-    expect(sortByOwner.attributes("aria-sort")).toBe(DESC)
+    const wrapper = getWrapperWithProps()
+    const sortBySharedWith = getSortBySharedWith(wrapper)
+    const sortByOwner = getSortByOwner(wrapper)
 
     await sortBySharedWith.trigger("click")
 

--- a/src/components/table/OcTableFilesSort.spec.js
+++ b/src/components/table/OcTableFilesSort.spec.js
@@ -1,7 +1,6 @@
-import { mount, shallowMount } from "@vue/test-utils"
+import { mount } from "@vue/test-utils"
 
 import Table from "./OcTableFiles.vue"
-import OcButton from "../OcButton"
 
 const ASC = "ascending"
 const DESC = "descending"

--- a/src/components/table/mixins/sort.js
+++ b/src/components/table/mixins/sort.js
@@ -11,6 +11,7 @@ export default {
   }),
   created() {
     if (this.isSortable) {
+      this.sortBy = this.firstSortableField
       this.$on(EVENT_THEAD_CLICKED, this.handleSort)
     }
   },
@@ -23,7 +24,7 @@ export default {
         const folders = [...this.data.filter(i => i.type === "folder")].sort((a, b) =>
           this.sortData(a, b)
         )
-        const files = [...this.data.filter(i => i.type === "file")].sort((a, b) =>
+        const files = [...this.data.filter(i => i.type !== "folder")].sort((a, b) =>
           this.sortData(a, b)
         )
         if (this.sortDir === SORT_DIRECTION_ASC) {
@@ -35,6 +36,13 @@ export default {
     },
     isSortable() {
       return this.fields.some(f => f.sortable)
+    },
+    firstSortableField() {
+      const sortableFields = this.fields.filter(f => f.sortable).map(f => f.name)
+      if (sortableFields) {
+        return sortableFields[0]
+      }
+      return null
     },
   },
   methods: {


### PR DESCRIPTION
## Description
This PR
- enforces an initial `sort-by` value, which gets computed from the first sortable field in the list of fields in `OcTableFiles`
- fixes sorting by dates by not comparing relative dates anymore, but comparing unix timestamps instead.

## Related Issue
- Fixes https://github.com/owncloud/owncloud-design-system/issues/1552
- Works towards https://github.com/owncloud/web/issues/5614
- Works towards https://github.com/owncloud/web/issues/5490

## Motivation and Context
Improve UX

## How Has This Been Tested?
- added/adapted unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
