### PR TITLE
Fix chevron icons

### DIFF
--- a/changelog/9.1.0_2021-08-17/enhancement-add-sidebar-toggle-icons
+++ b/changelog/9.1.0_2021-08-17/enhancement-add-sidebar-toggle-icons
@@ -1,7 +1,8 @@
 Enhancement: Add sidebar toggle icons 
 
-We added two new icons for the toggle button to switch between
+We added new chevron icons for the toggle button to switch between
 sidebar open and close
 
 https://github.com/owncloud/web/issues/5165
 https://github.com/owncloud/owncloud-design-system/pull/1587
+https://github.com/owncloud/owncloud-design-system/pull/1592

--- a/src/assets/icons/arrow_back.svg
+++ b/src/assets/icons/arrow_back.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M11.67 3.87L9.9 2.1 0 12l9.9 9.9 1.77-1.77L3.54 12z"/></svg>

--- a/src/assets/icons/arrow_forward.svg
+++ b/src/assets/icons/arrow_forward.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 24 24" ><g><path d="M0,0h24v24H0V0z" fill="none"/></g><g><polygon points="6.23,20.23 8,22 18,12 8,2 6.23,3.77 14.46,12"/></g></svg>

--- a/src/assets/icons/chevron_double_down.svg
+++ b/src/assets/icons/chevron_double_down.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M16.59,5.59L18,7L12,13L6,7L7.41,5.59L12,10.17L16.59,5.59M16.59,11.59L18,13L12,19L6,13L7.41,11.59L12,16.17L16.59,11.59Z" />
+</svg>

--- a/src/assets/icons/chevron_double_left.svg
+++ b/src/assets/icons/chevron_double_left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M18.41,7.41L17,6L11,12L17,18L18.41,16.59L13.83,12L18.41,7.41M12.41,7.41L11,6L5,12L11,18L12.41,16.59L7.83,12L12.41,7.41Z" />
+</svg>

--- a/src/assets/icons/chevron_double_right.svg
+++ b/src/assets/icons/chevron_double_right.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M5.59,7.41L7,6L13,12L7,18L5.59,16.59L10.17,12L5.59,7.41M11.59,7.41L13,6L19,12L13,18L11.59,16.59L16.17,12L11.59,7.41Z" />
+</svg>

--- a/src/assets/icons/chevron_double_up.svg
+++ b/src/assets/icons/chevron_double_up.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M7.41,18.41L6,17L12,11L18,17L16.59,18.41L12,13.83L7.41,18.41M7.41,12.41L6,11L12,5L18,11L16.59,12.41L12,7.83L7.41,12.41Z" />
+</svg>

--- a/src/assets/icons/chevron_down.svg
+++ b/src/assets/icons/chevron_down.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M0 0h24v24H0z" fill="none"/>
-    <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+    <path d="M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z" />
 </svg>

--- a/src/assets/icons/chevron_left.svg
+++ b/src/assets/icons/chevron_left.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/><path d="M0 0h24v24H0z" fill="none"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>
+</svg>

--- a/src/assets/icons/chevron_up.svg
+++ b/src/assets/icons/chevron_up.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
     <path d="M0 0h24v24H0z" fill="none"/>
-    <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>
+    <path d="M7.41,15.41L12,10.83L16.59,15.41L18,14L12,8L6,14L7.41,15.41Z" />
 </svg>


### PR DESCRIPTION
Deleted the arrow icons, since they were kind of duplicating the `chevron` icons that we already have. Made the chevron icon set more complete by adding `top` and `bottom` directions for single chevrons and adding all directions for double chevrons. See screenshot below.

<img width="438" alt="Screenshot 2021-08-17 at 13 39 58" src="https://user-images.githubusercontent.com/3532843/129719802-57c17d44-f15d-4997-b80f-4931fae18eda.png">
