### PR TITLE
Use pointer cursor for OcSelect actions

### DIFF
--- a/changelog/unreleased/bugfix-use-pointer-cursor-for-ocselect-actions
+++ b/changelog/unreleased/bugfix-use-pointer-cursor-for-ocselect-actions
@@ -1,0 +1,7 @@
+Bugfix: Use pointer cursor for OcSelect actions
+
+We changed the cursor for the actions (down/up arrows) on `OcSelect` to `pointer`.
+It used to be a `text` cursor.
+
+
+https://github.com/owncloud/owncloud-design-system/pull/1604

--- a/src/components/OcSelect.vue
+++ b/src/components/OcSelect.vue
@@ -117,6 +117,8 @@ export default {
       svg {
         overflow: visible;
       }
+
+      cursor: pointer;
     }
 
     &__clear svg {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the issue tracker for the design system. 

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of the ownCloud design system.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Assignment: assign to self
-->

## Description
I changed the cursor for the actions (usually the down/up arrows) on `OcSelect` to `default`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/customer_portal/issues/1067

## Motivation and Context
Currently a `text` cursor is shown for the down/up arrows in `OcSelect` which is confusing because clicking it does not trigger a text edit but expands/collapses the drop down menu.
Alternatively a `pointer` cursor (like for the "clear-X") could be used. My chromium on Linux uses `default` for regular `<select>` tags fwiw.

I can add a changelog entry if you otherwise approve this PR.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- checked in generated documentation :) 

## Screenshots (if appropriate):
before:
![Screenshot_20210822_211720](https://user-images.githubusercontent.com/448487/130367334-225ca212-5550-4bfb-b751-5f37a713a07d.png)
after:
![Screenshot_20210822_211604](https://user-images.githubusercontent.com/448487/130367311-dc89e42c-46bc-4679-b194-b2037e4219db.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
