### PR TITLE
Reset row background on dragDrop event in OcTable

### DIFF
--- a/changelog/unreleased/bugfix-reset-droptarget-background
+++ b/changelog/unreleased/bugfix-reset-droptarget-background
@@ -1,0 +1,7 @@
+Bugfix: Reset droptarget background color in OcTableFiles 
+
+The targeted table row in the OcTableFiles gets highlighted background when 
+another resource is dragged over it for visual user feedback, but the background 
+wasn't reset upon a successful drop event, which has been fixed.
+
+https://github.com/owncloud/owncloud-design-system/pull/1625

--- a/src/components/OcSelect.vue
+++ b/src/components/OcSelect.vue
@@ -287,7 +287,7 @@ We can then retrieve all the values that we want to display from the slots param
     })
   };
 </script>
-<style scoped>
+<style>
   .option {
     display: block;
   }

--- a/src/components/table/OcTable.vue
+++ b/src/components/table/OcTable.vue
@@ -46,7 +46,7 @@
         "
         @hook:mounted="$emit(constants.EVENT_TROW_MOUNTED, item, $refs[`row-${trIndex}`][0])"
         @dragstart.native.stop="dragStart(item)"
-        @drop.native.stop="dropRowEvent"
+        @drop.native.stop="dropRowEvent(item.id, $event)"
         @dragenter.native.prevent.stop="dropRowStyling(item.id, false, $event)"
         @dragleave.native.prevent.stop="dropRowStyling(item.id, true, $event)"
         @mouseleave="dropRowStyling(item.id, true, $event)"
@@ -249,15 +249,16 @@ export default {
       if (!this.dragDrop) return
       this.$emit(EVENT_FILE_DRAGGED, file)
     },
-    dropRowEvent(event) {
+    dropRowEvent(id, event) {
       if (!this.dragDrop) return
       const dropTarget = event.target
       const dropTargetTr = dropTarget.closest("tr")
       const dropFileId = dropTargetTr.dataset.fileId
+      this.dropRowStyling(id, true, event)
       this.$emit(EVENT_FILE_DROPPED, dropFileId)
     },
     dropRowStyling(id, leaving, event) {
-      if (event.currentTarget.contains(event.relatedTarget)) {
+      if (event.currentTarget?.contains(event.relatedTarget)) {
         return
       }
 


### PR DESCRIPTION
## Description
Thanks @paulcod3 for the hint, wasn't visible in the ODS but got discovered once the `EVENT_FILE_DROPPED` actually did something inside `web`