### PR TITLE
refactor(pagination): use route query object instead of param

### DIFF
--- a/changelog/unreleased/change-pagination-page-param
+++ b/changelog/unreleased/change-pagination-page-param
@@ -1,4 +1,4 @@
-Enhancement: Use route query to store active page
+Change: Use route query to store active page
 
 We've switched the storage of current paginated page to use route query object instead of param.
 

--- a/changelog/unreleased/enhancement-pagination-page-param
+++ b/changelog/unreleased/enhancement-pagination-page-param
@@ -1,0 +1,5 @@
+Enhancement: Use route query to store active page
+
+We've switched the storage of current paginated page to use route query object instead of param.
+
+https://github.com/owncloud/owncloud-design-system/pull/1626

--- a/src/components/pagination/OcPagination.spec.js
+++ b/src/components/pagination/OcPagination.spec.js
@@ -118,11 +118,11 @@ describe("OcPagination", () => {
 
     expect(Pagination.computed.previousPageLink.call(localThis)).toMatchObject({
       name: "files",
-      params: { page: 2 },
+      query: { page: 2 },
     })
     expect(Pagination.computed.nextPageLink.call(localThis)).toMatchObject({
       name: "files",
-      params: { page: 4 },
+      query: { page: 4 },
     })
   })
 })

--- a/src/components/pagination/OcPagination.vue
+++ b/src/components/pagination/OcPagination.vue
@@ -192,11 +192,8 @@ export default {
     bindPageLink(page) {
       return {
         name: this.currentRoute.name,
-        query: this.currentRoute.query,
-        params: {
-          ...this.currentRoute.params,
-          page,
-        },
+        query: { ...this.currentRoute.query, page },
+        params: this.currentRoute.params,
       }
     },
   },


### PR DESCRIPTION
instead of having current pagination page as param refactor it to
use the query route object

BREAKING CHANGE: this could break in some cases where the implementing
logic relies on route page param, to fix switch to use route query
object