### PR TITLE
OcCheckbox: add support for showing default values and clear buttons

### DIFF
--- a/src/components/OcCheckbox.vue
+++ b/src/components/OcCheckbox.vue
@@ -11,6 +11,15 @@
       :disabled="disabled"
     />
     <label :for="id" :class="labelClasses" v-text="label" />
+    <oc-button
+      v-if="showClearButton"
+      :aria-label="clearButtonAccessibleLabelValue"
+      appearance="raw"
+      @click="onClear"
+    >
+      <oc-icon name="close" size="small" variation="passive" />
+    </oc-button>
+
   </span>
 </template>
 
@@ -32,6 +41,22 @@ export default {
       type: String,
       required: false,
       default: () => uniqueId("oc-checkbox-"),
+    },
+    /**
+     * Whether or not the checkbox should have a dedicated button for clearing the value (revert to default).
+     */
+    clearButtonEnabled: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
+    /**
+     * The aria label for the clear button. Only used if it's enabled at all.
+     */
+    clearButtonAccessibleLabel: {
+      type: String,
+      required: false,
+      default: "",
     },
     /**
      * Value to show when no value is provided
@@ -106,6 +131,9 @@ export default {
     classes() {
       return ["oc-checkbox", "oc-checkbox-" + getSizeClass(this.size)]
     },
+    clearButtonAccessibleLabelValue() {
+      return this.clearButtonAccessibleLabel || this.$gettext("Clear input")
+    },
     displayValue() {
       if (this.value === null) {
         return this.defaultValue
@@ -121,8 +149,14 @@ export default {
         "oc-cursor-pointer": !this.disabled,
       }
     },
+    showClearButton() {
+      return this.clearButtonEnabled && this.value !== null
+    },
   },
   methods: {
+    onClear() {
+      this.onInput(null)
+    },
     onInput(value) {
       this.$emit("input", value)
     }
@@ -235,12 +269,12 @@ We can provide a `defaultValue` to `oc-checkbox` that is shown when `value` is `
       Providing a default value
     </h3>
     <div class="oc-mb-s">
-      <oc-checkbox :default-value="false" v-model="uncheckedByDefault" label="Checkbox unchecked by default" aria-label="Checkbox unchecked by default"/>
+      <oc-checkbox :default-value="false" :clearButtonEnabled="true" v-model="uncheckedByDefault" label="Checkbox unchecked by default" aria-label="Checkbox unchecked by default"/>
       <br/>
       <span>Value: {{ uncheckedByDefault !== null && uncheckedByDefault.toString() || "null" }} </span>
     </div>
     <div class="oc-mb-s">
-      <oc-checkbox :default-value="true" v-model="checkedByDefault" label="Checkbox checked by default" aria-label="Checkbox checked by default"/>
+      <oc-checkbox :default-value="true" :clearButtonEnabled="true" v-model="checkedByDefault" label="Checkbox checked by default" aria-label="Checkbox checked by default"/>
       <br/>
       <span>Value: {{ checkedByDefault !== null && checkedByDefault.toString() || "null" }} </span>
     </div>

--- a/src/components/OcCheckbox.vue
+++ b/src/components/OcCheckbox.vue
@@ -33,6 +33,17 @@ export default {
       default: () => uniqueId("oc-checkbox-"),
     },
     /**
+     * Value to show when no value is provided
+     * This does not set `value` automatically.
+     * The user needs to explicitly check or uncheck to set `value`.
+     */
+    defaultValue: {
+      // TODO: should we support arrays here? What would be the semantics?
+      type: Boolean,
+      required: false,
+      default: null,
+    },
+    /**
      * Disables the checkbox
      */
     disabled: {
@@ -48,7 +59,7 @@ export default {
     // eslint-disable-next-line vue/require-prop-types
     value: {
       required: false,
-      default: false,
+      default: null,
     },
     /**
      * The value/object this checkbox represents.
@@ -93,7 +104,7 @@ export default {
   computed: {
     model: {
       get() {
-        return this.value
+        return typeof this.value === 'boolean' ? this.value : this.defaultValue
       },
       set: function (value) {
         this.$emit("input", value)
@@ -115,7 +126,9 @@ export default {
   },
   methods: {
     setChecked: function (value) {
-      if (typeof value === "boolean") {
+      if (value === null) {
+        this.checked = this.defaultValue
+      } else if (typeof value === "boolean") {
         this.checked = value
       } else {
         this.checked = value.includes(this.option)
@@ -220,6 +233,39 @@ label > .oc-checkbox + span {
   </section>
 </template>
 ```
+
+We can provide a `defaultValue` to `oc-checkbox` that is shown when `value` is `null`.
+
+```js
+<template>
+  <section>
+    <h3 class="oc-heading-divider oc-mt-s">
+      Providing a default value
+    </h3>
+    <div class="oc-mb-s">
+      <oc-checkbox :default-value="false" v-model="uncheckedByDefault" label="Checkbox unchecked by default" aria-label="Checkbox unchecked by default"/>
+      <br/>
+      <span>Value: {{ uncheckedByDefault !== null && uncheckedByDefault.toString() || "null" }} </span>
+    </div>
+    <div class="oc-mb-s">
+      <oc-checkbox :default-value="true" v-model="checkedByDefault" label="Checkbox checked by default" aria-label="Checkbox checked by default"/>
+      <br/>
+      <span>Value: {{ checkedByDefault !== null && checkedByDefault.toString() || "null" }} </span>
+    </div>
+  </section>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      uncheckedByDefault: null,
+      checkedByDefault: null,
+    }
+  }
+}
+</script>
+```
+
 ```js
 <template>
   <section>

--- a/src/components/OcCheckbox.vue
+++ b/src/components/OcCheckbox.vue
@@ -2,7 +2,8 @@
   <span>
     <input
       :id="id"
-      v-model="model"
+      :checked="displayValue"
+      @input="onInput($event.target.checked)"
       type="checkbox"
       name="checkbox"
       :class="classes"
@@ -102,17 +103,17 @@ export default {
     },
   },
   computed: {
-    model: {
-      get() {
-        return typeof this.value === 'boolean' ? this.value : this.defaultValue
-      },
-      set: function (value) {
-        this.$emit("input", value)
-        this.setChecked(value)
-      },
-    },
     classes() {
       return ["oc-checkbox", "oc-checkbox-" + getSizeClass(this.size)]
+    },
+    displayValue() {
+      if (this.value === null) {
+        return this.defaultValue
+      } else if (typeof this.value === "boolean") {
+        return this.value
+      }
+
+      return this.value.includes(this.option)
     },
     labelClasses() {
       return {
@@ -121,19 +122,10 @@ export default {
       }
     },
   },
-  created() {
-    this.setChecked(this.model)
-  },
   methods: {
-    setChecked: function (value) {
-      if (value === null) {
-        this.checked = this.defaultValue
-      } else if (typeof value === "boolean") {
-        this.checked = value
-      } else {
-        this.checked = value.includes(this.option)
-      }
-    },
+    onInput(value) {
+      this.$emit("input", value)
+    }
   },
 }
 </script>

--- a/src/components/OcCheckbox.vue
+++ b/src/components/OcCheckbox.vue
@@ -48,7 +48,7 @@ export default {
     clearButtonEnabled: {
       type: Boolean,
       required: false,
-      default: true,
+      default: false,
     },
     /**
      * The aria label for the clear button. Only used if it's enabled at all.


### PR DESCRIPTION
## Description
This PR adds support for showing default values and a clear button to `OcCheckbox`.

It's not beautiful (visually) by any means and the same UX problems as for #1634 apply here too.

Needs UX concept by @kulmann and @tbsbdr 

## Related Issue
- #1634
- Fixes 3 :x: from  #1350
    (`@change`, `clearButtonEnabled` and `defaultValue`)

## Motivation and Context
See #1634 

## How Has This Been Tested?

## Screenshots (if appropriate):
Nothing selected by user
![Screenshot_20210905_124232](https://user-images.githubusercontent.com/448487/132123917-7ad2e09f-e5b5-479d-9e8d-3c18b67324d0.png)
Clicked once to switch value:
![Screenshot_20210905_124309](https://user-images.githubusercontent.com/448487/132123932-99907c7e-589b-4dac-b7e7-24892ab81c5a.png)
Clicked twice to explicitly set value:
![Screenshot_20210905_124336](https://user-images.githubusercontent.com/448487/132123941-554fa05d-0dba-408c-8e62-535a6b167a6f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
