### PR TITLE
OcTextInput: add defaultValue prop and make clear button null the value

### DIFF
--- a/changelog/unreleased/enhancement-octextinput-props
+++ b/changelog/unreleased/enhancement-octextinput-props
@@ -1,0 +1,10 @@
+Enhancement: Streamline OcTextInput
+
+We have updated the OcTextInput component to be in line with other form components in the design system.
+
+- Fixed the clear button being visible even when element is disabled
+- Made clear button emit null instead of empty string
+- Made input/change event handling a bit more consistent
+- Added defaultValue prop that is for now passed as placeholder to the input field
+
+https://github.com/owncloud/owncloud-design-system/pull/1636

--- a/src/components/molecules/OcTextInput/OcTextInput.spec.js
+++ b/src/components/molecules/OcTextInput/OcTextInput.spec.js
@@ -165,7 +165,11 @@ describe("OcTextInput", () => {
 
   describe("clear input", () => {
     it("has no clear button when it is disabled", () => {
-      const wrapper = getShallowWrapper({ value: "non-empty-value" })
+      const wrapper = getShallowWrapper({
+        value: "non-empty-value",
+        clearButtonEnabled: true,
+        disabled: true,
+      })
       expect(wrapper.find(selectors.clearInputButton).exists()).toBeFalsy()
     })
 

--- a/src/components/molecules/OcTextInput/OcTextInput.spec.js
+++ b/src/components/molecules/OcTextInput/OcTextInput.spec.js
@@ -173,10 +173,19 @@ describe("OcTextInput", () => {
       expect(wrapper.find(selectors.clearInputButton).exists()).toBeFalsy()
     })
 
-    it("has no clear button when it is enabled but the input is empty", () => {
+    it("has clear button when it is enabled but the input is an empty string but not null", () => {
       const wrapper = getShallowWrapper({
         clearButtonEnabled: true,
         value: "",
+      })
+
+      expect(wrapper.find(selectors.clearInputButton).exists()).toBeTruthy()
+    })
+
+    it("has no clear button when it is enabled but the input is null", () => {
+      const wrapper = getShallowWrapper({
+        clearButtonEnabled: true,
+        value: null,
       })
 
       expect(wrapper.find(selectors.clearInputButton).exists()).toBeFalsy()
@@ -207,8 +216,11 @@ describe("OcTextInput", () => {
 
       await btn.trigger("click")
 
-      expect(wrapper.emitted().input[0][0]).toEqual("")
-      expect(input.element.value).toEqual("")
+      // value as data is supposed to be `null`
+      expect(wrapper.emitted().input[0][0]).toEqual(null)
+      // value in DOM would be the empty string if two way binding was used
+      // by just passing in the value it should remain unchanged
+      expect(input.element.value).toEqual("non-empty-value")
       expect(document.activeElement.id).toBe(input.element.id)
     })
   })

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -14,6 +14,7 @@
         }"
         :type="type"
         :value="value"
+        :disabled="disabled"
         v-on="listeners"
         @input="onInput($event.target.value)"
         @focus="onFocus($event.target)"
@@ -112,6 +113,13 @@ export default {
       default: "",
     },
     /**
+     * Disables the input field
+     */
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+    /**
      * Accessible of the form input field, via aria-label.
      **/
     label: {
@@ -199,7 +207,7 @@ export default {
       return this.descriptionMessage
     },
     showClearButton() {
-      return this.clearButtonEnabled && this.value && this.value.length > 0
+      return !this.disabled && this.clearButtonEnabled && this.value && this.value.length > 0
     },
     clearButtonAccessibleLabelValue() {
       return this.clearButtonAccessibleLabel || this.$gettext("Clear input")

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -13,7 +13,7 @@
           'oc-text-input-danger': !!errorMessage,
         }"
         :type="type"
-        :value="value"
+        :value="displayValue"
         :disabled="disabled"
         v-on="listeners"
         @change="onChange($event.target.value)"
@@ -228,6 +228,9 @@ export default {
     clearButtonAccessibleLabelValue() {
       return this.clearButtonAccessibleLabel || this.$gettext("Clear input")
     },
+    displayValue() {
+      return this.value || ""
+    }
   },
   methods: {
     /**
@@ -341,7 +344,7 @@ export default {
     <oc-text-input label="Clear input" v-model="inputValueForClearing" :clear-button-enabled="true" />
     <oc-text-input label="Input with default" v-model="inputValueWithDefault" :clear-button-enabled="true" default-value="Some default"/>
     <p>
-      Value: {{ inputValueWithDefault || "null" }}
+      Value: {{ inputValueWithDefault !== null ? inputValueWithDefault : "null" }}
     </p>
     <h3 class="oc-heading-divider">
       Messages

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -207,7 +207,7 @@ export default {
       return this.descriptionMessage
     },
     showClearButton() {
-      return !this.disabled && this.clearButtonEnabled && this.value && this.value.length > 0
+      return !this.disabled && this.clearButtonEnabled && this.value !== null
     },
     clearButtonAccessibleLabelValue() {
       return this.clearButtonAccessibleLabel || this.$gettext("Clear input")

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -114,6 +114,16 @@ export default {
       default: "",
     },
     /**
+     * Value to show when no value is provided
+     * This does not set `value` automatically.
+     * The user needs to explicitly enter a text to set it as `value`.
+     */
+    defaultValue: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    /**
      * Disables the input field
      */
     disabled: {
@@ -191,6 +201,10 @@ export default {
       const additionalAttrs = {}
       if (!!this.warningMessage || !!this.errorMessage || !!this.descriptionMessage) {
         additionalAttrs["aria-describedby"] = this.messageId
+      }
+      // FIXME: placeholder usage is discouraged, we need to find a better UX concept
+      if (this.defaultValue) {
+        additionalAttrs["placeholder"] = this.defaultValue
       }
       return { ...this.$attrs, ...additionalAttrs }
     },
@@ -325,6 +339,10 @@ export default {
     <oc-button @click="_focusAndSelect">Focus and select input below</oc-button>
     <oc-text-input label="Select field" value="Will you select this existing text?" ref="inputForFocusSelect"/>
     <oc-text-input label="Clear input" v-model="inputValueForClearing" :clear-button-enabled="true" />
+    <oc-text-input label="Input with default" v-model="inputValueWithDefault" :clear-button-enabled="true" default-value="Some default"/>
+    <p>
+      Value: {{ inputValueWithDefault || "null" }}
+    </p>
     <h3 class="oc-heading-divider">
       Messages
     </h3>
@@ -358,6 +376,7 @@ export default {
         inputValue: 'initial',
         valueForMessages: '',
         inputValueForClearing: 'clear me',
+        inputValueWithDefault: null,
       }
     },
     computed: {

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -224,7 +224,7 @@ export default {
     onClear() {
       this.$refs.input.value = ""
       this.$refs.input.focus()
-      this.onInput("")
+      this.onInput(null)
     },
     onInput(value) {
       /**

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -230,7 +230,7 @@ export default {
     },
     displayValue() {
       return this.value || ""
-    }
+    },
   },
   methods: {
     /**

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -224,7 +224,7 @@ export default {
       this.$refs.input.focus()
     },
     onClear() {
-      this.$refs.input.focus()
+      this.focus()
 
       this.onInput(null)
       this.onChange(null)

--- a/src/components/molecules/OcTextInput/OcTextInput.vue
+++ b/src/components/molecules/OcTextInput/OcTextInput.vue
@@ -16,6 +16,7 @@
         :value="value"
         :disabled="disabled"
         v-on="listeners"
+        @change="onChange($event.target.value)"
         @input="onInput($event.target.value)"
         @focus="onFocus($event.target)"
       />
@@ -177,6 +178,7 @@ export default {
       const listeners = this.$listeners
 
       // Delete listeners for events which are emitted via methods
+      delete listeners["change"]
       delete listeners["input"]
       delete listeners["focus"]
 
@@ -222,9 +224,17 @@ export default {
       this.$refs.input.focus()
     },
     onClear() {
-      this.$refs.input.value = ""
       this.$refs.input.focus()
+
       this.onInput(null)
+      this.onChange(null)
+    },
+    onChange(value) {
+      /**
+       * Change event
+       * @type {event}
+       **/
+      this.$emit("change", value)
     },
     onInput(value) {
       /**


### PR DESCRIPTION
## Description
1) Fixed the clear button being visible even when element is disabled
2) Made clear button emit `null` instead of empty string
3) Made input/change event handling a bit more consistent
4) Added `defaultValue` prop that is for now passed as `placeholder` to the input field. 

Needs UX concept by @kulmann and @tbsbdr

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes one :x: from #1350 (`defaultValue`) and makes it more consistent with other components that also emit `null` on clear (which is not part of that table)

## Motivation and Context
Same as #1634 and #1635 

Instead of using native `placeholder` prop on the `input` element, I would propose to introduce the `defaultValue` property which for now uses `placeholder` but keeps that as implementation detail. That way I can already use the functionality in ownBrander 2.0 and will automatically benefit from a better implementation at some point in the future.

## How Has This Been Tested?


## Screenshots (if appropriate):
Only visual change: it's now possible to have an empty input field with clear button.
That is useful when a user overrides the default value with an empty string.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
     we don't emit empty strings anymore on clear, but afaict `clearButtonEnabled` is used nowhere, so this shouldn't break anything in ownCloud
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
