### PR TITLE
Make accessible description on OcAvatars optional

### DIFF
--- a/changelog/unreleased/change-refactor-oc-avatars
+++ b/changelog/unreleased/change-refactor-oc-avatars
@@ -6,3 +6,4 @@ or hovered.
 
 https://github.com/owncloud/web/issues/5736
 https://github.com/owncloud/owncloud-design-system/pull/1614
+https://github.com/owncloud/owncloud-design-system/pull/1639

--- a/src/components/avatars/OcAvatarFederated.vue
+++ b/src/components/avatars/OcAvatarFederated.vue
@@ -8,10 +8,12 @@
 </template>
 
 <script>
+import OcAvatarItem from "./OcAvatarItem"
 export default {
   name: "OcAvatarFederated",
   status: "review",
   release: "",
+  components: { OcAvatarItem },
 
   props: {
     /**

--- a/src/components/avatars/OcAvatarGroup.vue
+++ b/src/components/avatars/OcAvatarGroup.vue
@@ -3,10 +3,12 @@
 </template>
 
 <script>
+import OcAvatarItem from "./OcAvatarItem"
 export default {
   name: "OcAvatarGroup",
   status: "review",
   release: "",
+  components: { OcAvatarItem },
 
   props: {
     /**

--- a/src/components/avatars/OcAvatarGuest.vue
+++ b/src/components/avatars/OcAvatarGuest.vue
@@ -8,10 +8,12 @@
 </template>
 
 <script>
+import OcAvatarItem from "./OcAvatarItem"
 export default {
   name: "OcAvatarGuest",
   status: "review",
   release: "",
+  components: { OcAvatarItem },
 
   props: {
     /**

--- a/src/components/avatars/OcAvatarLink.vue
+++ b/src/components/avatars/OcAvatarLink.vue
@@ -3,10 +3,12 @@
 </template>
 
 <script>
+import OcAvatarItem from "./OcAvatarItem"
 export default {
   name: "OcAvatarLink",
   status: "ready",
   release: "2.1.0",
+  components: { OcAvatarItem },
 
   props: {
     /**

--- a/src/components/avatars/OcAvatars.vue
+++ b/src/components/avatars/OcAvatars.vue
@@ -25,7 +25,7 @@
       </template>
       <oc-avatar-count v-if="isOverlapping" :count="items.length - maxDisplayed" />
     </div>
-    <span class="oc-invisible-sr" v-text="accessibleDescription" />
+    <span v-if="accessibleDescription" class="oc-invisible-sr" v-text="accessibleDescription" />
   </div>
 </template>
 
@@ -93,7 +93,8 @@ export default {
      */
     accessibleDescription: {
       type: String,
-      required: true,
+      required: false,
+      default: null,
     },
   },
 

--- a/src/components/avatars/OcAvatars.vue
+++ b/src/components/avatars/OcAvatars.vue
@@ -189,42 +189,43 @@ export default {
   </div>
 </template>
 <script>
+import { shareType } from "../../utils/shareType"
 export default {
   data: () => ({
     items: [
       {
         name: "bob",
-        shareType: 6
+        shareType: shareType.remote
       },
       {
         username: "marie",
         displayName: "Marie",
         avatar: "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
-        shareType: 0
+        shareType: shareType.user
       },
       {
         username: "peter",
         displayName: "Peter",
         avatar: "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
-        shareType: 0
+        shareType: shareType.user
       },
       {
         username: "udo",
         displayName: "Udo",
         avatar: "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
-        shareType: 0
+        shareType: shareType.user
       },
       {
         name: "john",
-        shareType: 4
+        shareType: shareType.guest
       },
       {
         name: "Public link",
-        shareType: 3
+        shareType: shareType.link
       },
       {
         name: "Test",
-        shareType: 1
+        shareType: shareType.group
       }
     ]
   })

--- a/src/components/avatars/OcAvatars.vue
+++ b/src/components/avatars/OcAvatars.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <div
+  <span>
+    <span
       v-oc-tooltip="tooltip"
       class="oc-avatars"
       :class="{ 'oc-avatars-stacked': stacked }"
@@ -24,9 +24,9 @@
         />
       </template>
       <oc-avatar-count v-if="isOverlapping" :count="items.length - maxDisplayed" />
-    </div>
+    </span>
     <span v-if="accessibleDescription" class="oc-invisible-sr" v-text="accessibleDescription" />
-  </div>
+  </span>
 </template>
 
 <script>
@@ -161,7 +161,8 @@ export default {
 
 <style lang="scss">
 .oc-avatars {
-  display: flex;
+  display: inline-flex;
+  box-sizing: border-box;
   flex-flow: row wrap;
   gap: var(--oc-space-xsmall);
   width: fit-content;

--- a/src/components/avatars/OcAvatars.vue
+++ b/src/components/avatars/OcAvatars.vue
@@ -183,8 +183,14 @@ export default {
 ```js
 <template>
   <div>
+    <h3>Default configuration</h3>
+    <p>No stacking, no tooltip, no <b>:maxDisplayed</b> configured</p>
     <oc-avatars :items="items" accessible-description="This resource is shared with many users." class="oc-mb" />
-    <oc-avatars :items="items" accessible-description="This resource is shared with many users." :stacked="true" :isTooltipDisplayed="true" :maxDisplayed="5" class="oc-mb" />
+    <h3>Stacked, tooltip, maxDisplayed</h3>
+    <p>Using <b>:stacked="true"</b>, <b>:isTooltipDisplayed="true"</b> and <b>:maxDisplayed="5"</b></p>
+    <oc-avatars :items="items" accessible-description="This resource is shared with many users." :stacked="true" :maxDisplayed="5" :isTooltipDisplayed="true" />
+    <h3>Unstacked, tooltip, maxDisplayed</h3>
+    <p>Using <b>:isTooltipDisplayed="true"</b> and <b>:maxDisplayed="2"</b></p>
     <oc-avatars :items="items" accessible-description="This resource is shared with many users." :maxDisplayed="2" :isTooltipDisplayed="true" />
   </div>
 </template>

--- a/src/components/avatars/__snapshots__/OcAvatars.spec.js.snap
+++ b/src/components/avatars/__snapshots__/OcAvatars.spec.js.snap
@@ -1,37 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcAvatars displays tooltip 1`] = `
-<div>
-  <div aria-hidden="true" class="oc-avatars">
-    <oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Bob" accessiblelabel="" width="30"></oc-avatar-stub>
-    <oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Marie" accessiblelabel="" width="30"></oc-avatar-stub>
-    <!---->
-    <oc-avatar-count-stub count="3" size="30"></oc-avatar-count-stub>
-  </div> <span class="oc-invisible-sr">List of users</span>
-</div>
-`;
+exports[`OcAvatars displays tooltip 1`] = `<span><span aria-hidden="true" class="oc-avatars"><oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Bob" accessiblelabel="" width="30"></oc-avatar-stub><oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Marie" accessiblelabel="" width="30"></oc-avatar-stub> <!----> <oc-avatar-count-stub count="3" size="30"></oc-avatar-count-stub></span> <span class="oc-invisible-sr">List of users</span></span>`;
 
-exports[`OcAvatars prefers avatars over links when maxDisplayed is exceeded 1`] = `
-<div>
-  <div aria-hidden="true" class="oc-avatars">
-    <oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Bob" accessiblelabel="" width="30"></oc-avatar-stub>
-    <oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Marie" accessiblelabel="" width="30"></oc-avatar-stub>
-    <oc-avatar-stub src="" username="John Richards Emperor of long names" accessiblelabel="" width="30"></oc-avatar-stub>
-    <!---->
-    <oc-avatar-count-stub count="2" size="30"></oc-avatar-count-stub>
-  </div> <span class="oc-invisible-sr">List of users</span>
-</div>
-`;
+exports[`OcAvatars prefers avatars over links when maxDisplayed is exceeded 1`] = `<span><span aria-hidden="true" class="oc-avatars"><oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Bob" accessiblelabel="" width="30"></oc-avatar-stub><oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Marie" accessiblelabel="" width="30"></oc-avatar-stub><oc-avatar-stub src="" username="John Richards Emperor of long names" accessiblelabel="" width="30"></oc-avatar-stub> <!----> <oc-avatar-count-stub count="2" size="30"></oc-avatar-count-stub></span> <span class="oc-invisible-sr">List of users</span></span>`;
 
-exports[`OcAvatars shows avatars first and links last 1`] = `
-<div>
-  <div aria-hidden="true" class="oc-avatars">
-    <oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Bob" accessiblelabel="" width="30"></oc-avatar-stub>
-    <oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Marie" accessiblelabel="" width="30"></oc-avatar-stub>
-    <oc-avatar-stub src="" username="John Richards Emperor of long names" accessiblelabel="" width="30"></oc-avatar-stub>
-    <ocavatarlink-stub name="link 0" accessiblelabel=""></ocavatarlink-stub>
-    <ocavatarlink-stub name="link 1" accessiblelabel=""></ocavatarlink-stub>
-    <!---->
-  </div> <span class="oc-invisible-sr">List of users</span>
-</div>
-`;
+exports[`OcAvatars shows avatars first and links last 1`] = `<span><span aria-hidden="true" class="oc-avatars"><oc-avatar-stub src="https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Bob" accessiblelabel="" width="30"></oc-avatar-stub><oc-avatar-stub src="https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&amp;ixlib=rb-1.2.1&amp;auto=format&amp;fit=crop&amp;w=800&amp;q=60" username="Marie" accessiblelabel="" width="30"></oc-avatar-stub><oc-avatar-stub src="" username="John Richards Emperor of long names" accessiblelabel="" width="30"></oc-avatar-stub> <ocavatarlink-stub name="link 0" accessiblelabel=""></ocavatarlink-stub><ocavatarlink-stub name="link 1" accessiblelabel=""></ocavatarlink-stub> <!----></span> <span class="oc-invisible-sr">List of users</span></span>`;

--- a/src/components/table/OcTableFiles.vue
+++ b/src/components/table/OcTableFiles.vue
@@ -679,6 +679,8 @@ export default {
   <oc-table-files :resources="resources" :arePathsDisplayed="true" v-model="selected" />
 </template>
 <script>
+  import { shareType } from "../../utils/shareType"
+
   export default {
     data: () => ({
       selected: []
@@ -724,18 +726,21 @@ export default {
             id: "bob",
             username: "bob",
             displayName: "Bob",
-            avatar: "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60"
+            avatar: "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            shareType: shareType.user
           },
           {
             id: "marie",
             username: "marie",
             displayName: "Marie",
-            avatar: "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60"
+            avatar: "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            shareType: shareType.user
           },
           {
             id: "john",
             username: "john",
-            displayName: "John Richards Emperor of long names"
+            displayName: "John Richards Emperor of long names",
+            shareType: shareType.user
           }
         ]
       },
@@ -745,23 +750,27 @@ export default {
             id: "bob",
             username: "bob",
             displayName: "Bob",
-            avatar: "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60"
+            avatar: "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            shareType: shareType.user
           },
           {
             id: "marie",
             username: "marie",
             displayName: "Marie",
-            avatar: "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60"
+            avatar: "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            shareType: shareType.user
           },
           {
             id: "john",
             username: "john",
-            displayName: "John Richards Emperor of long names"
+            displayName: "John Richards Emperor of long names",
+            shareType: shareType.user
           },
           {
             id: "einstein",
             username: "einstein",
-            displayName: "Einstein"
+            displayName: "Einstein",
+            shareType: shareType.user
           }
         ]
       },
@@ -771,7 +780,8 @@ export default {
             id: "bob",
             username: "bob",
             displayName: "Bob",
-            avatar: "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60"
+            avatar: "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            shareType: shareType.user
           }
         ]
       }


### PR DESCRIPTION
Make accessible description on OcAvatars optional

Also fixed imports of the OcAvatarItem in more specific items on the way.