### PR TITLE
fix: prevent hover style on footer of <oc-table>

### DIFF
--- a/changelog/unreleased/bugfix-prevent-hover-style-on-oc-table-footer
+++ b/changelog/unreleased/bugfix-prevent-hover-style-on-oc-table-footer
@@ -1,0 +1,3 @@
+Bugfix: Prevent hover style on footer of <oc-table>
+
+https://github.com/owncloud/owncloud-design-system/pull/1667

--- a/src/components/table/OcTable.vue
+++ b/src/components/table/OcTable.vue
@@ -68,7 +68,7 @@
       </oc-tr>
     </oc-tbody>
     <tfoot v-if="$slots.footer" class="oc-table-footer">
-      <tr>
+      <tr class="oc-table-footer-row">
         <td :colspan="footerColspan" class="oc-table-footer-cell">
           <!-- @slot Footer of the table -->
           <slot name="footer" />
@@ -416,7 +416,7 @@ export default {
     border-top: 1px solid var(--oc-color-border);
   }
 
-  &-hover tr:hover {
+  &-hover tr:not(&-footer-row):hover {
     background-color: var(--oc-color-input-border);
   }
 


### PR DESCRIPTION
## Description
This fix is to prevent the <tfooter> element from receiving the hover style (when rendering a `<oc-table>` component with `hover="true"` as it makes it appear as another row in the table which isn't accurate and probably not good for accessibility.  Typically at the bottom there are totals about the size of the files / folders used.

**Before**
![image](https://user-images.githubusercontent.com/876651/134100822-2b8d8fae-ac35-4500-802a-2c65352b254d.png)

**After**
![image](https://user-images.githubusercontent.com/876651/134100833-7ecadb3a-e947-4e15-866e-f3b0dd156a83.png)

## Motivation and Context
Makes the table interface cleaner (especially when there are only a few files / folders) - makes it not seem broken (eg. is there a hidden file or folder?) and correctly separates any data or table summary info in the footer from the main row content.

## How Has This Been Tested?
Tested in Chrome and IE (edge) browsers and works as expected.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
