### PR TITLE
Add word-break rule to OcModal

### DIFF
--- a/changelog/unreleased/bugfix-modal-word-break
+++ b/changelog/unreleased/bugfix-modal-word-break
@@ -1,0 +1,6 @@
+Bugfix: Add word-break rule to OcModal component
+
+We had issues with long filenames overflowing the OcModal body.
+
+https://github.com/owncloud/owncloud-design-system/issues/1712
+https://github.com/owncloud/owncloud-design-system/pulls/1736

--- a/src/components/molecules/OcNotificationMessage/OcNotificationMessage.vue
+++ b/src/components/molecules/OcNotificationMessage/OcNotificationMessage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="oc-alert" :class="classes">
+  <div class="oc-alert oc-notification-message" :class="classes">
     <oc-icon :variation="iconVariation" size="large" name="info" class="oc-mr-s" />
     <div
       class="uk-flex uk-flex-wrap uk-flex-middle uk-flex-1 oc-mr"
@@ -106,6 +106,10 @@ export default {
 </script>
 
 <style lang="scss">
+.oc-notification-message {
+  word-break: break-word;
+}
+
 // TODO: Refactor after removal of uikit
 .uk-notification-message {
   background-color: var(--oc-color-background-default) !important;


### PR DESCRIPTION
## Description
The OcModal / OcNotification / OcAlert code & styling seems a bit messy in its current state, but we can probably address this when implementing the new screendesigns. This is a simple fix for a UI glitch in `web`

## Related Issue
- Fixes #1712
