### PR TITLE
A11y fix sufficient contrast

### DIFF
--- a/src/components/__snapshots__/OcModal.spec.js.snap
+++ b/src/components/__snapshots__/OcModal.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OcModal displays input 1`] = `
-<div aria-labelledby="oc-modal-title" class="oc-modal-background">
+<div class="oc-modal-background">
   <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
-    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+    <div tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->
         <h2 id="oc-modal-title">Create new folder</h2>
@@ -21,9 +21,9 @@ exports[`OcModal displays input 1`] = `
 `;
 
 exports[`OcModal hides icon if not specified 1`] = `
-<div aria-labelledby="oc-modal-title" class="oc-modal-background">
+<div class="oc-modal-background">
   <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
-    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+    <div tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->
         <h2 id="oc-modal-title">Example title</h2>
@@ -41,9 +41,9 @@ exports[`OcModal hides icon if not specified 1`] = `
 `;
 
 exports[`OcModal matches snapshot 1`] = `
-<div aria-labelledby="oc-modal-title" class="oc-modal-background">
+<div class="oc-modal-background">
   <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
-    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+    <div tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <oc-icon-stub name="info" accessiblelabel="" type="span" size="medium" variation="passive"></oc-icon-stub>
         <h2 id="oc-modal-title">Example title</h2>
@@ -61,9 +61,9 @@ exports[`OcModal matches snapshot 1`] = `
 `;
 
 exports[`OcModal overrides props message with slot 1`] = `
-<div aria-labelledby="oc-modal-title" class="oc-modal-background">
+<div class="oc-modal-background">
   <focus-trap-stub escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
-    <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
+    <div tabindex="0" role="dialog" aria-modal="true" aria-labelledby="oc-modal-title" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->
         <h2 id="oc-modal-title">Example title</h2>

--- a/src/tokens/ods/color.yaml
+++ b/src/tokens/ods/color.yaml
@@ -1,20 +1,20 @@
 ---
 color:
-#  sample:
-#    default:
-#      value: "{color.swatch.warning.hover.value}"
-#      check:
-#        contrast:
-#          ratio: 3.5
-#          background:
-#            - "{color.background.default.value}"
-#            - "{color.background.muted.value}"
-#      transform:
-#        darken: 23
-#        lighten: 10
-#        brighten: 10
-#        desaturate: 10
-#        saturate: 10
+  #  sample:
+  #    default:
+  #      value: "{color.swatch.warning.hover.value}"
+  #      check:
+  #        contrast:
+  #          ratio: 3.5
+  #          background:
+  #            - "{color.background.default.value}"
+  #            - "{color.background.muted.value}"
+  #      transform:
+  #        darken: 23
+  #        lighten: 10
+  #        brighten: 10
+  #        desaturate: 10
+  #        saturate: 10
   swatch:
     brand:
       default:
@@ -95,6 +95,6 @@ color:
       muted:
         value: "{color.swatch.passive.default.value}"
     border:
-      value: rgb(206, 221, 238)
+      value: rgb(48, 91, 139)
     bg:
       value: rgb(240, 244, 248)

--- a/src/tokens/ods/color.yaml
+++ b/src/tokens/ods/color.yaml
@@ -95,6 +95,6 @@ color:
       muted:
         value: "{color.swatch.passive.default.value}"
     border:
-      value: rgb(48, 91, 139)
+      value: rgb(64,121,186)
     bg:
       value: rgb(240, 244, 248)


### PR DESCRIPTION
## Description
Changed the border color for inputs and checkboxes so it has a contrast ratio of at least 3:1. New contrast ratio is now 7.01:1.

## Related Issue
- Works towards https://github.com/owncloud/web/issues/5386

## How Has This Been Tested?
- Used this contrast checker to determine the right color: https://webaim.org/resources/contrastchecker/

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:

**Page 1 (Alle Dateien)**
When creating a public link in the case the user doesn’t fill the fields a error message appears above the form. This error message has a „X“ button on the right (to remove the message). Here the contrast ration to the background color is lower than 3:1.

Not able to reproduce this scenario, as there is no error message being displayed. Instead the submit button is just disabled as long the required input field is empty.
