### PR TITLE
Add grouping functionality to OcTableFiles

### DIFF
--- a/src/components/templates/OcTableFiles/OcTableFiles.vue
+++ b/src/components/templates/OcTableFiles/OcTableFiles.vue
@@ -1,5 +1,6 @@
 <template>
   <oc-table
+    :grouping-settings="groupingSettings"
     :data="resources"
     :fields="fields"
     :highlighted="selectedIds"
@@ -145,6 +146,17 @@ export default {
     event: "select",
   },
   props: {
+    /**
+     * Grouping settings for the table. Following settings are possible:<br />
+     * -**groupingFunctions**: Object with keys as grouping options names and functions that get a table data row and return a group name for that row. The names of the functions are used as grouping options.
+     * -**groupingBy**: must be either one of the keys in groupingFunctions or 'None'. If not set, default grouping will be 'None'.<br />
+     * -**ShowGroupingOptions**:  boolean value for showing or hinding the select element with grouping options above the table. <br />
+     * -**PreviewAmount**: Integer value that is used to show only the first n data rows of the table.
+     */
+    groupingSettings: {
+      type: Object,
+      required: false,
+    },
     /**
      * Resources to be displayed in the table.
      * Required fields:
@@ -931,7 +943,233 @@ export default {
 
           case 1:
             return "Pending"
+          case 2:
+            return "Declined"
+        }
+      }
+    }
+  }
+</script>
+```
 
+## Shared with me files table with grouping options
+```js
+<template>
+  <oc-table-files :resources="resources" :arePathsDisplayed="true" v-model="selected" :groupingSettings="groupingSettings">
+  </oc-table-files>
+</template>
+<script>
+  export default {
+    data: () => ({
+      selected: []
+    }),
+    computed: {
+      groupingSettings(){
+        return {
+          groupingBy: "owner",
+          showGroupingOptions: true,
+          previewAmount: 4,
+          groupingFunctions: {
+            "owner": function(row) {
+              return row.owner[0].displayName
+            },
+            "alphabetically": function(row) {
+              return row.name.charAt(0).toLowerCase()
+            },
+            "creation": function(row) {
+              let now = new Date()
+              let interval1 = new Date()
+              interval1.setDate(interval1.getDate()-7)
+              let interval2 = new Date()
+              interval2.setDate(interval2.getDate()-30)
+
+              if (Date.parse(row.sdate)>interval1.getTime()){
+                return "Recent"
+              } else if (Date.parse(row.sdate)>interval2.getTime()){
+                return "This Month"
+              } else return "Older"
+            }
+          },
+          functionColMappings: {
+            "Share owner": "owner",
+            "Shared on": "sdate"
+          }
+      }
+    },
+    resources() {
+      return [
+        {
+          id: "A",
+          name: "A",
+          path: "/Documents",
+          icon: "folder",
+          indicators: [],
+          type: "folder",
+          sdate: "Mon, 29 Jun 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "marie",
+              username: "marie",
+              displayName: "Marie",
+              avatar:
+                "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 2,
+        },
+        {id: "B",
+          name: "B",
+          path: "/Documents",
+          icon: "folder",
+          indicators: [],
+          type: "folder",
+          sdate: "Mon, 4 May 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "marie",
+              username: "marie",
+              displayName: "Marie",
+              avatar:
+                "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 2,
+        },
+        {id: "D",
+          name: "D",
+          path: "/Documents",
+          icon: "folder",
+          indicators: [],
+          type: "folder",
+          sdate: "Mon, 6 May 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "marie",
+              username: "marie",
+              displayName: "Marie",
+              avatar:
+                "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 2,
+        },
+        {id: "Dodo",
+          name: "Dodo",
+          path: "/Documents",
+          icon: "folder",
+          indicators: [],
+          type: "folder",
+          sdate: "Mon, 15 May 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "marie",
+              username: "marie",
+              displayName: "Marie",
+              avatar:
+                "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 2,
+        },
+        {id: "C",
+          name: "C",
+          path: "/Documents",
+          icon: "folder",
+          indicators: [],
+          type: "folder",
+          sdate: "Mon, 17 May 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "marie",
+              username: "marie",
+              displayName: "Marie",
+              avatar:
+                "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 2,
+        },
+        {id: "Aforest.jpg",
+          name: "Aforest.jpg",
+          path: "images/nature/forest.jpg",
+          preview: "https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg",
+          indicators: [],
+          type: "file",
+          sdate: "Mon, 11 Jan 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "bob",
+              username: "bob",
+              displayName: "Bob",
+              avatar:
+                "https://images.unsplash.com/photo-1610216705422-caa3fcb6d158?ixid=MXwxMjA3fDB8MHxzZWFyY2h8MTB8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 1,
+        },
+        {id: "ag.txt",
+          name: "ag.txt",
+          path: "/Documents/notes.txt",
+          icon: "text",
+          indicators: [],
+          type: "file",
+          sdate: "Mon, 11 Jan 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "einstein",
+              username: "einstein",
+              displayName: "Einstein",
+            },
+          ],
+          status: 0,
+        },
+        {id: "H",
+          name: "H",
+          path: "/Documents",
+          icon: "folder",
+          indicators: [],
+          type: "folder",
+          sdate: "Mon, 07 Jun 2021 14:34:04 GMT",
+          owner: [
+            {
+              id: "marie",
+              username: "marie",
+              displayName: "Marie",
+              avatar:
+                "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 2,
+        },
+        {id: "Hey",
+          name: "Hey",
+          path: "/Documents",
+          icon: "folder",
+          indicators: [],
+          type: "folder",
+          sdate: "Mon, 11 Jan 2020 14:34:04 GMT",
+          owner: [
+            {
+              id: "marie",
+              username: "marie",
+              displayName: "Marie",
+              avatar:
+                "https://images.unsplash.com/photo-1584308972272-9e4e7685e80f?ixid=MXwxMjA3fDB8MHxzZWFyY2h8Mzh8fGZhY2V8ZW58MHwyfDB8&ixlib=rb-1.2.1&auto=format&fit=crop&w=800&q=60",
+            },
+          ],
+          status: 2,
+        },
+      ]
+    },
+  },
+    methods: {
+
+      shareStatus(status) {
+        switch (status) {
+          case 0:
+            return "Accepted"
+          case 1:
+            return "Pending"
           case 2:
             return "Declined"
         }


### PR DESCRIPTION
## Description
Grouping as well as preview functionality for the tables. 

Setup is done with the property "groupingSettings" . Following settings are possible:
- groupingFunctions: Object with keys as grouping options names and functions that get a table data row and return a group name for that row. The names of the functions are used as grouping options. 

- groupingBy: must be either one of the keys in groupingFunctions or 'None'. If not set, default grouping will be 'None'.
- ShowGroupingOptions: boolean value for showing or hinding the select element with grouping options above the table.
- PreviewAmount: Integer value that is used to show only the first n data rows of the table.object


![Screenshot from 2021-09-08 10-47-39](https://user-images.githubusercontent.com/7430156/132478203-38f7ef88-78a8-4591-a7cf-7ede8356a436.png)


## Related Issue


## Motivation and Context
UX-friendly option to make the table more



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- Tests



