### PR TITLE
A11y fix skip areas

### DIFF
--- a/src/components/OcSidebarNav.spec.js
+++ b/src/components/OcSidebarNav.spec.js
@@ -10,29 +10,29 @@ const defaultProps = {
 const slots = {
   header: '<span class="header">Logo</span>',
   nav: '<span class="nav">Nav</span>',
-  footer: '<span class="footer">Footer</span>'
+  footer: '<span class="footer">Footer</span>',
 }
 
 describe("OcSidebarNav", () => {
-  it('displays all slots', () => {
+  it("displays all slots", () => {
     const wrapper = shallowMount(Sidebar, {
       propsData: defaultProps,
-      slots
+      slots,
     })
 
-    expect(wrapper.findAll('.header').length).toBe(1)
-    expect(wrapper.findAll('.nav').length).toBe(1)
-    expect(wrapper.findAll('.footer').length).toBe(1)
+    expect(wrapper.findAll(".header").length).toBe(1)
+    expect(wrapper.findAll(".nav").length).toBe(1)
+    expect(wrapper.findAll(".footer").length).toBe(1)
   })
 
-  it('sets all accessible labels', () => {
+  it("sets all accessible labels", () => {
     const wrapper = shallowMount(Sidebar, {
       propsData: defaultProps,
-      slots
+      slots,
     })
 
-    expect(wrapper.find('header').attributes()['aria-label']).toMatch('sidebar-header')
-    expect(wrapper.find('nav').attributes()['aria-label']).toMatch('sidebar-nav')
-    expect(wrapper.find('footer').attributes()['aria-label']).toMatch('sidebar-footer')
+    expect(wrapper.find("figure").attributes()["aria-label"]).toMatch("sidebar-header")
+    expect(wrapper.find("nav").attributes()["aria-label"]).toMatch("sidebar-nav")
+    expect(wrapper.find("footer").attributes()["aria-label"]).toMatch("sidebar-footer")
   })
 })

--- a/src/components/OcSidebarNav.spec.js
+++ b/src/components/OcSidebarNav.spec.js
@@ -1,5 +1,4 @@
 import { shallowMount } from "@vue/test-utils"
-import CompressionPlugin from "compression-webpack-plugin"
 import Sidebar from "./OcSidebarNav.vue"
 
 const defaultProps = {

--- a/src/components/OcSidebarNav.vue
+++ b/src/components/OcSidebarNav.vue
@@ -5,14 +5,14 @@
     :class="[data.staticClass, data.class]"
     v-bind="data.attrs"
   >
-    <header
+    <figure
       v-if="slots().header"
       class="oc-sidebar-header"
       :aria-label="props.accessibleLabelHeader"
     >
       <!-- @slot Header of the sidebar -->
       <slot name="header" />
-    </header>
+    </figure>
     <nav v-if="slots().nav" class="oc-sidebar-nav" :aria-label="props.accessibleLabelNav">
       <!-- @slot Main content of the sidebar -->
       <slot name="nav" />
@@ -71,7 +71,7 @@ export default {
   padding: var(--oc-space-large) 0 var(--oc-space-medium);
   width: var(--oc-size-width-medium);
 
-  &-header {
+  &-figure {
     margin-bottom: var(--oc-space-xxlarge);
     padding: 0 var(--oc-space-medium);
   }

--- a/src/components/OcSidebarNav.vue
+++ b/src/components/OcSidebarNav.vue
@@ -71,7 +71,7 @@ export default {
   padding: var(--oc-space-large) 0 var(--oc-space-medium);
   width: var(--oc-size-width-medium);
 
-  &-figure {
+  &-header {
     margin-bottom: var(--oc-space-xxlarge);
     padding: 0 var(--oc-space-medium);
   }


### PR DESCRIPTION
## Description
Replaced `header` element in sidebar navigation with `figure` element in order to avoid having two `header` elements on the same page.

## Related Issue
- Works towards https://github.com/owncloud/web/issues/5391

## How Has This Been Tested?
- Dev tools
- WAVE browser extension

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
