### PR TITLE
Add padding size for OcDrop

### DIFF
--- a/changelog/unreleased/enhancement-drop-padding-size
+++ b/changelog/unreleased/enhancement-drop-padding-size
@@ -1,5 +1,6 @@
 Enhancement: Optional padding size for OcDrop
 
-We've added a `paddingSize` property to the OcDrop component for specifying a dedicated padding of the div that wraps the content slot. It defaults to "medium" and also allows to remove the padding entirely.
+We've added a `paddingSize` property to the OcDrop component for specifying a dedicated padding of the div that wraps the content slot.
+It defaults to "medium" and also allows to remove the padding entirely.
 
 https://github.com/owncloud/owncloud-design-system/pull/1798

--- a/changelog/unreleased/enhancement-drop-padding-size
+++ b/changelog/unreleased/enhancement-drop-padding-size
@@ -1,0 +1,5 @@
+Enhancement: Optional padding size for OcDrop
+
+We've added a `paddingSize` property to the OcDrop component for specifying a dedicated padding of the div that wraps the content slot. It defaults to "medium" and also allows to remove the padding entirely.
+
+https://github.com/owncloud/owncloud-design-system/pull/1798

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -1,6 +1,10 @@
 <template>
   <div :id="dropId" ref="drop" class="oc-drop" @click="$_ocDrop_close">
-    <div v-if="$slots.default" class="uk-card uk-card-default uk-card-small uk-card-body">
+    <div
+      v-if="$slots.default"
+      class="uk-card uk-card-default uk-card-small uk-card-body"
+      :class="paddingClass"
+    >
       <slot />
     </div>
     <slot v-else name="special" />
@@ -11,6 +15,7 @@
 import tippy, { hideAll } from "tippy.js"
 import { destroy, hideOnEsc } from "../../../directives/OcTooltip"
 import uniqueId from "../../../utils/uniqueId"
+import { getSizeClass } from "../../../utils/sizeClasses"
 
 /**
  * Position any element in relation to another element.
@@ -81,6 +86,19 @@ export default {
       required: false,
       default: null,
     },
+    /**
+     * Defines the padding size around the drop content. Defaults to `medium`.
+     *
+     * @values xsmall, small, medium, large, xlarge, xxlarge, xxxlarge, remove
+     */
+    paddingSize: {
+      type: String,
+      required: false,
+      default: "medium",
+      validator: value => {
+        return value.match(/(xsmall|small|medium|large|xlarge|xxlarge|xxxlarge|remove)/)
+      },
+    },
   },
   data() {
     return { tippy: null }
@@ -92,6 +110,9 @@ export default {
           hover: "mouseenter focus",
         }[this.mode] || this.mode
       )
+    },
+    paddingClass() {
+      return `oc-p-${getSizeClass(this.paddingSize)}`
     },
   },
   watch: {

--- a/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
+++ b/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcDrop renders tippy 1`] = `
+exports[`OcDrop tippy renders tippy 1`] = `
 <div>
   <p
-    aria-describedby="tippy-3"
+    aria-describedby="tippy-10"
     aria-expanded="true"
     id="trigger"
   >
@@ -11,7 +11,7 @@ exports[`OcDrop renders tippy 1`] = `
   </p>
   <div
     data-tippy-root=""
-    id="tippy-3"
+    id="tippy-10"
     style="z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
   >
     <div
@@ -33,10 +33,10 @@ exports[`OcDrop renders tippy 1`] = `
       >
         <div
           class="oc-drop"
-          id="oc-drop-8"
+          id="oc-drop-15"
         >
           <div
-            class="uk-card uk-card-default uk-card-small uk-card-body"
+            class="uk-card uk-card-default uk-card-small uk-card-body oc-p-m"
           >
             show
           </div>
@@ -47,7 +47,7 @@ exports[`OcDrop renders tippy 1`] = `
 </div>
 `;
 
-exports[`OcDrop renders tippy 2`] = `
+exports[`OcDrop tippy renders tippy 2`] = `
 <div>
   <p
     aria-expanded="false"
@@ -57,7 +57,7 @@ exports[`OcDrop renders tippy 2`] = `
   </p>
   <div
     data-tippy-root=""
-    id="tippy-3"
+    id="tippy-10"
     style="z-index: 9999; visibility: hidden; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px); pointer-events: none;"
   >
     <div
@@ -79,10 +79,10 @@ exports[`OcDrop renders tippy 2`] = `
       >
         <div
           class="oc-drop"
-          id="oc-drop-8"
+          id="oc-drop-15"
         >
           <div
-            class="uk-card uk-card-default uk-card-small uk-card-body"
+            class="uk-card uk-card-default uk-card-small uk-card-body oc-p-m"
           >
             show
           </div>
@@ -93,10 +93,10 @@ exports[`OcDrop renders tippy 2`] = `
 </div>
 `;
 
-exports[`OcDrop renders tippy 3`] = `
+exports[`OcDrop tippy renders tippy 3`] = `
 <div>
   <p
-    aria-describedby="tippy-3"
+    aria-describedby="tippy-10"
     aria-expanded="true"
     id="trigger"
   >
@@ -104,7 +104,7 @@ exports[`OcDrop renders tippy 3`] = `
   </p>
   <div
     data-tippy-root=""
-    id="tippy-3"
+    id="tippy-10"
     style="z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
   >
     <div
@@ -126,10 +126,10 @@ exports[`OcDrop renders tippy 3`] = `
       >
         <div
           class="oc-drop"
-          id="oc-drop-8"
+          id="oc-drop-15"
         >
           <div
-            class="uk-card uk-card-default uk-card-small uk-card-body"
+            class="uk-card uk-card-default uk-card-small uk-card-body oc-p-m"
           >
             show
           </div>

--- a/src/components/molecules/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.js.snap
+++ b/src/components/molecules/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.js.snap
@@ -28,7 +28,7 @@ exports[`OcBreadcrumb displays all items 1`] = `
   <div class="oc-breadcrumb-drop"><label tabindex="0" class="oc-breadcrumb-drop-label"><span aria-current="page" class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
       <oc-icon-stub name="expand_more" accessiblelabel="Expand more" type="span" size="medium" variation="passive" class="oc-breadcrumb-drop-label-icon"></oc-icon-stub>
     </label>
-    <oc-drop-stub dropid="oc-drop-2" toggle="" position="bottom-start" mode="click" options="[object Object]">
+    <oc-drop-stub dropid="oc-drop-2" toggle="" position="bottom-start" mode="click" paddingsize="medium" options="[object Object]">
       <ol class="uk-nav uk-nav-default">
         <li>
           <router-link-stub tag="a" to="[object Object]">
@@ -79,7 +79,7 @@ exports[`OcBreadcrumb sets correct variation 1`] = `
   <div class="oc-breadcrumb-drop"><label tabindex="0" class="oc-breadcrumb-drop-label"><span aria-current="page" class="oc-breadcrumb-drop-label-text">Deeper ellipsize in responsive mode</span>
       <oc-icon-stub name="expand_more" accessiblelabel="Expand more" type="span" size="medium" variation="passive" class="oc-breadcrumb-drop-label-icon"></oc-icon-stub>
     </label>
-    <oc-drop-stub dropid="oc-drop-1" toggle="" position="bottom-start" mode="click" options="[object Object]">
+    <oc-drop-stub dropid="oc-drop-1" toggle="" position="bottom-start" mode="click" paddingsize="medium" options="[object Object]">
       <ol class="uk-nav uk-nav-default">
         <li>
           <router-link-stub tag="a" to="[object Object]">

--- a/src/components/templates/OcTableFiles/OcTableFiles.vue
+++ b/src/components/templates/OcTableFiles/OcTableFiles.vue
@@ -98,6 +98,7 @@
           :popper-options="popperOptions"
           mode="click"
           close-on-click
+          padding-size="remove"
           @click.native.stop.prevent
         >
           <!-- @slot Add context actions that open in a dropdown when clicking on the "three dots" button -->

--- a/src/utils/sizeClasses.js
+++ b/src/utils/sizeClasses.js
@@ -8,6 +8,7 @@ const sizeClassMappings = {
   xlarge: "xl",
   xxlarge: "xxl",
   xxxlarge: "xxxl",
+  remove: "rm",
 }
 
 export function getSizeClass(size) {


### PR DESCRIPTION
## Description
We've added a `paddingSize` property to the OcDrop component for specifying a dedicated padding of the div that wraps the content slot. It defaults to "medium" and also allows to remove the padding entirely.

## Motivation and Context
Being able to remove the padding of an OcDrop where it's not needed / ugly (e.g. role selection for shares in web).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- added unit tests for padding size to class transformation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
