### PR TITLE
Set current language for formatted dates

### DIFF
--- a/changelog/unreleased/bugfix-language-formatted-dates
+++ b/changelog/unreleased/bugfix-language-formatted-dates
@@ -1,0 +1,5 @@
+Bugfix: Set language for date formatting
+
+We're now setting the language when formatting dates, so that localized parts of the date/time get shown according to the respective language.
+
+https://github.com/owncloud/owncloud-design-system/pull/1806

--- a/src/components/templates/OcTableFiles/OcTableFiles.vue
+++ b/src/components/templates/OcTableFiles/OcTableFiles.vue
@@ -440,6 +440,10 @@ export default {
     contextMenuLabel() {
       return this.$gettext("Show context menu")
     },
+
+    currentLanguage() {
+      return (this.$language?.current || "").split("_")[0]
+    },
   },
   methods: {
     fileDragged(file) {
@@ -506,13 +510,15 @@ export default {
       this.emitSelect([resource])
     },
     formatDate(date) {
-      return DateTime.fromJSDate(new Date(date)).toLocaleString(DateTime.DATETIME_FULL)
+      return DateTime.fromJSDate(new Date(date))
+        .setLocale(this.currentLanguage)
+        .toLocaleString(DateTime.DATETIME_FULL)
     },
     formatDateRelative(date) {
-      return DateTime.fromJSDate(new Date(date)).toRelative()
+      return DateTime.fromJSDate(new Date(date)).setLocale(this.currentLanguage).toRelative()
     },
     unixDate(date) {
-      return DateTime.fromJSDate(new Date(date)).valueOf()
+      return DateTime.fromJSDate(new Date(date)).setLocale(this.currentLanguage).valueOf()
     },
 
     emitSelect(resources) {


### PR DESCRIPTION
## Description
Now setting the language when formatting dates, so that localized parts of the date/time get shown according to the respective language.

## Motivation and Context
Correct localization

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
