### PR TITLE
Remove padding from breadcrumb context menu

### DIFF
--- a/changelog/11.3.1_2021-12-03/bugfix-breadcrumb-contextmenu-padding
+++ b/changelog/11.3.1_2021-12-03/bugfix-breadcrumb-contextmenu-padding
@@ -1,0 +1,5 @@
+Bugfix: Padding in breadcrumb context menu
+
+We've removed the padding from the context menu in the breadcrumbs to align its visual appearance with the context menu in the files table.
+
+https://github.com/owncloud/owncloud-design-system/pull/1813

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "owncloud-design-system",
-  "version": "11.3.0",
+  "version": "11.3.1",
   "description": "ownCloud Design System is based on VueDesign Systems and is used to design ownCloud UI components",
   "keywords": [
     "vue design system",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 sonar.projectKey=owncloud_owncloud-design-system
 sonar.organization=owncloud-1
 sonar.projectName=owncloud-design-system
-sonar.projectVersion=11.3.0
+sonar.projectVersion=11.3.1
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================

--- a/src/components/molecules/OcBreadcrumb/OcBreadcrumb.vue
+++ b/src/components/molecules/OcBreadcrumb/OcBreadcrumb.vue
@@ -14,13 +14,12 @@
           {{ item.text }}
         </oc-button>
         <span v-else :aria-current="getAriaCurrent(index)" tabindex="-1" v-text="item.text" />
-        <template v-if="showContextMenu && index == items.length - 1">
+        <template v-if="showContextMenu && index === items.length - 1">
           <oc-button
             id="oc-breadcrumb-contextmenu-trigger"
             v-oc-tooltip="contextMenuLabel"
             :aria-label="contextMenuLabel"
             appearance="raw"
-            :variation="primary"
           >
             <oc-icon name="more_vert" />
           </oc-button>
@@ -29,6 +28,7 @@
             toggle="#oc-breadcrumb-contextmenu-trigger"
             mode="click"
             close-on-click
+            padding-size="remove"
             @click.native.stop.prevent
           >
             <!-- @slot Add context actions that open in a dropdown when clicking on the "three dots" button -->


### PR DESCRIPTION
## Description
Removes the padding from the context menu in the breadcrumbs to align its visual appearance with the context menu in the files table. Also bumping the version number for an immediate bugfix release.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
