### PR TITLE
Extract sort handling from OcTable

### DIFF
--- a/changelog/unreleased/change-externalize-oc-table-sorting
+++ b/changelog/unreleased/change-externalize-oc-table-sorting
@@ -1,0 +1,8 @@
+Change: Do not sort in OcTable
+
+We removed sorting from OcTable and added a `sort` event instead, which can be used to sort the data externally.
+This is crucial for server side sorting and handling pagination correctly.
+
+https://github.com/owncloud/owncloud-design-system/pull/1825
+https://github.com/owncloud/web/pull/6136
+https://github.com/owncloud/web/issues/5687

--- a/src/components/molecules/OcTable/OcTable.sort.spec.js
+++ b/src/components/molecules/OcTable/OcTable.sort.spec.js
@@ -68,22 +68,9 @@ describe("OcTable.sort", () => {
     })
   })
 
-  it("sorts by the first sortable field by default (= without interaction)", () => {
-    const wrapper = mount(Table, {
-      propsData: {
-        fields: [...tableFields],
-        data,
-      },
-    })
-    const firstSortableFieldIndex = tableFields.findIndex(f => f.sortable)
-    const headers = wrapper.findAll("thead th")
-    for (let i = 0; i < firstSortableFieldIndex; i++) {
-      expect(headers.at(i).attributes()["aria-sort"]).toBeFalsy()
-    }
-    expect(headers.at(firstSortableFieldIndex).attributes()["aria-sort"]).toEqual(DESC)
-  })
-
-  it("can sort", async () => {
+  it("emits sort events", async () => {
+    let click = 0
+    let sortArgs
     const wrapper = mount(Table, {
       propsData: {
         fields: tableFields,
@@ -94,27 +81,37 @@ describe("OcTable.sort", () => {
     const th1 = headers.at(1)
     const th2 = headers.at(2)
 
-    expect(th1.attributes("aria-sort")).toBe(DESC)
+    expect(th1.attributes("aria-sort")).toBe(NONE)
     expect(th2.attributes("aria-sort")).toBe(NONE)
-    expect(wrapper.findAll("tbody tr td").at(1).text()).toBe("1245")
-    expect(wrapper.findAll("tbody tr td").at(2).text()).toBe("id-3")
+    expect(wrapper.findAll("tbody tr td").at(1).text()).toBe("111000234")
+    expect(wrapper.findAll("tbody tr td").at(2).text()).toBe("id-1")
 
     await th1.trigger("click")
+    sortArgs = { sortBy: "id", sortDir: "desc" }
+    expect(wrapper.emitted("sort")[click++]).toMatchObject([sortArgs])
+    await wrapper.setProps(sortArgs)
+    expect(th1.attributes("aria-sort")).toBe(DESC)
+    expect(th2.attributes("aria-sort")).toBe(NONE)
+
+    await th1.trigger("click")
+    sortArgs = { sortBy: "id", sortDir: "asc" }
+    expect(wrapper.emitted("sort")[click++]).toMatchObject([sortArgs])
+    await wrapper.setProps(sortArgs)
     expect(th1.attributes("aria-sort")).toBe(ASC)
     expect(th2.attributes("aria-sort")).toBe(NONE)
-    expect(wrapper.findAll("tbody tr td").at(1).text()).toBe("111000234")
-    expect(wrapper.findAll("tbody tr td").at(2).text()).toBe("id-1")
 
     await th2.trigger("click")
+    sortArgs = { sortBy: "resource", sortDir: "asc" }
+    expect(wrapper.emitted("sort")[click++]).toMatchObject([sortArgs])
+    await wrapper.setProps(sortArgs)
     expect(th1.attributes("aria-sort")).toBe(NONE)
     expect(th2.attributes("aria-sort")).toBe(ASC)
-    expect(wrapper.findAll("tbody tr td").at(1).text()).toBe("1245")
-    expect(wrapper.findAll("tbody tr td").at(2).text()).toBe("id-3")
 
     await th2.trigger("click")
+    sortArgs = { sortBy: "resource", sortDir: "desc" }
+    expect(wrapper.emitted("sort")[click++]).toMatchObject([sortArgs])
+    await wrapper.setProps(sortArgs)
     expect(th1.attributes("aria-sort")).toBe(NONE)
     expect(th2.attributes("aria-sort")).toBe(DESC)
-    expect(wrapper.findAll("tbody tr td").at(1).text()).toBe("111000234")
-    expect(wrapper.findAll("tbody tr td").at(2).text()).toBe("id-1")
   })
 })

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -35,7 +35,7 @@
     </oc-thead>
     <oc-tbody>
       <oc-tr
-        v-for="(item, trIndex) in tableData"
+        v-for="(item, trIndex) in data"
         :key="`oc-tbody-tr-${itemDomSelector(item) || trIndex}`"
         :ref="`row-${trIndex}`"
         v-bind="extractTbodyTrProps(item, trIndex)"
@@ -247,9 +247,6 @@ export default {
     }
   },
   computed: {
-    tableData() {
-      return this.data
-    },
     tableClasses() {
       const result = ["oc-table"]
 

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -248,7 +248,7 @@ export default {
   },
   computed: {
     tableData() {
-      return this.sortedData || this.data
+      return this.data
     },
     tableClasses() {
       const result = ["oc-table"]
@@ -571,6 +571,78 @@ export default {
 <template>
   <section>
     <h3 class="oc-heading-divider">
+      A sortable table with plain field types
+    </h3>
+    <oc-table @sort="handleSort" :sort-by="sortBy" :sort-dir="sortDir" :fields="fields" :data="data" highlighted="4b136c0a-5057-11eb-ac70-eba264112003"
+      disabled="8468c9f0-5057-11eb-924b-934c6fd827a2" :sticky="true">
+      <template #footer>
+        3 resources
+      </template>
+    </oc-table>
+  </section>
+</template>
+<script>
+  const orderBy = (list, prop, desc) => {
+    return [...list].sort((a, b) => {
+      a = a[prop];
+      b = b[prop];
+
+      if (a == b) return 0;
+      return (desc ? a > b : a < b) ? -1 : 1;
+    });
+  };
+
+  export default {
+    data() {
+      return {
+        sortBy: 'resource',
+        sortDir: 'desc'
+      }
+    },
+    methods: {
+      handleSort(event) {
+        this.sortBy = event.sortBy
+        this.sortDir = event.sortDir
+
+      }
+    },
+    computed: {
+      fields() {
+        return [{
+          name: "resource",
+          title: "Resource",
+          alignH: "left",
+          sortable: true,
+        }, {
+          name: "last_modified",
+          title: "Last modified",
+          alignH: "right",
+          sortable: true,
+        }]
+      },
+      data() {
+        return orderBy([{
+          id: "4b136c0a-5057-11eb-ac70-eba264112003",
+          resource: "hello-world.txt",
+          last_modified: 1609962211
+        }, {
+          id: "8468c9f0-5057-11eb-924b-934c6fd827a2",
+          resource: "I am a folder",
+          last_modified: 1608887766
+        }, {
+          id: "9c4cf97e-5057-11eb-8044-b3d5df9caa21",
+          resource: "this is fine.png",
+          last_modified: 1599999999
+        }], this.sortBy, this.sortDir === 'desc')
+      }
+    }
+  }
+</script>
+```
+```js
+<template>
+  <section>
+    <h3 class="oc-heading-divider">
       A simple table with all existing field types
     </h3>
     <oc-table :fields="fields" :data="data">
@@ -633,6 +705,7 @@ export default {
   }
 </script>
 ```
+
 ```js
 <template>
   <section>

--- a/src/mixins/sort.js
+++ b/src/mixins/sort.js
@@ -5,76 +5,48 @@ const SORT_DIRECTION_ASC = "asc"
 const SORT_DIRECTION_DESC = "desc"
 
 export default {
-  data: () => ({
-    sortBy: null,
-    sortDir: SORT_DIRECTION_ASC,
-  }),
+  props: {
+    /**
+     * Show that the table is sorted by this column (no actual sorting takes place)
+     */
+    sortBy: {
+      type: String,
+      required: false,
+    },
+
+    /**
+     * Show that the table is sorted ascendingly/descendingly (no actual sorting takes place)
+     */
+    sortDir: {
+      type: String,
+      required: false,
+      default: undefined,
+      validator: value => {
+        return [SORT_DIRECTION_ASC, SORT_DIRECTION_DESC].includes(value)
+      },
+    },
+  },
   created() {
     if (this.isSortable) {
-      this.sortBy = this.firstSortableField
       this.$on(EVENT_THEAD_CLICKED, this.handleSort)
     }
   },
   computed: {
-    sortedData() {
-      if (!this.isSortable || !this.sortBy) {
-        return
-      }
-      if (this.sortBy === "name") {
-        const folders = [...this.data.filter(i => i.type === "folder")].sort((a, b) =>
-          this.sortData(a, b)
-        )
-        const files = [...this.data.filter(i => i.type !== "folder")].sort((a, b) =>
-          this.sortData(a, b)
-        )
-        if (this.sortDir === SORT_DIRECTION_ASC) {
-          return folders.concat(files)
-        }
-        return files.concat(folders)
-      }
-      return [...this.data].sort((a, b) => this.sortData(a, b))
-    },
     isSortable() {
       return this.fields.some(f => f.sortable)
     },
-    firstSortableField() {
-      const sortableFields = this.fields.filter(f => f.sortable).map(f => f.name)
-      if (sortableFields) {
-        return sortableFields[0]
-      }
-      return null
-    },
   },
   methods: {
-    sortData(a, b) {
-      let aValue = a[this.sortBy]
-      let bValue = b[this.sortBy]
-      const modifier = this.sortDir === SORT_DIRECTION_ASC ? 1 : -1
-
-      const { sortable } = this.fields.find(f => f.name === this.sortBy)
-
-      if (sortable) {
-        if (typeof sortable === "string") {
-          const genArrComp = vals => {
-            return vals.map(val => val[sortable]).join("")
-          }
-
-          aValue = genArrComp(aValue)
-          bValue = genArrComp(bValue)
-        } else if (typeof sortable === "function") {
-          aValue = sortable(aValue)
-          bValue = sortable(bValue)
-        }
+    extractSortThProps(props, field) {
+      if (!this.fieldIsSortable(field)) {
+        return
       }
 
-      if (!isNaN(aValue) && !isNaN(bValue)) {
-        return (aValue - bValue) * modifier
+      let sort = "none"
+      if (this.sortBy === field.name) {
+        sort = this.sortDir === SORT_DIRECTION_ASC ? "ascending" : "descending"
       }
-      const userLang = navigator.language || navigator.userLanguage
-      const compare = aValue
-        .toString()
-        .localeCompare(bValue.toString(), userLang, { sensitivity: "base" })
-      return compare * modifier
+      props["aria-sort"] = sort
     },
     fieldIsSortable({ sortable }) {
       return !!sortable
@@ -84,24 +56,22 @@ export default {
         return
       }
 
-      if (field.name === this.sortBy) {
-        this.sortDir =
-          this.sortDir === SORT_DIRECTION_ASC ? SORT_DIRECTION_DESC : SORT_DIRECTION_ASC
-        return
+      // only toggle sortDir if already sorted by this column
+      let sortDir = this.sortDir
+      if (field.name === this.sortBy || this.sortDir === undefined) {
+        sortDir = this.sortDir === SORT_DIRECTION_DESC ? SORT_DIRECTION_ASC : SORT_DIRECTION_DESC
       }
 
-      this.sortBy = field.name
-    },
-    extractSortThProps(props, field) {
-      if (!this.fieldIsSortable(field)) {
-        return
-      }
-
-      let sort = "none"
-      if (this.sortBy === field.name) {
-        sort = this.sortDir === SORT_DIRECTION_ASC ? "descending" : "ascending"
-      }
-      props["aria-sort"] = sort
+      /**
+       * Triggers when table heads are clicked
+       *
+       * @property {string} sortBy requested column to sort by
+       * @property {string} sortDir requested order to sort in (either asc or desc)
+       */
+      this.$emit("sort", {
+        sortBy: field.name,
+        sortDir,
+      })
     },
   },
 }


### PR DESCRIPTION
## Description
The sorting depends on the structure of resources which do not exist in ODS but only in web-app-files.
Moreover, we need to sort before pagination and as pagination is not handled in `OcTable` either, we need to handle sorting externally as well.
This has the additional benefit that this prepares us better for retrieving server sorted and paginated resources.

This is a draft and as such has a few rough edges.
For instance sorting has been added to the first example of `OcTable`, should we get this close to merging this would deserve its own section obviously :) 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
