### PR TITLE
[tests-only] refactored try catch use cases inside unit tests

### DIFF
--- a/src/components/atoms/OcButton/OcButton.spec.js
+++ b/src/components/atoms/OcButton/OcButton.spec.js
@@ -102,32 +102,22 @@ describe("OcButton", () => {
       ${"justifyContent"}
       ${"variation"}
       ${"gapSize"}
-    `('when prop "$prop" is set to an invalid value"', ({ prop, value }) => {
-      try {
-        let props = {}
-        props[prop] = "not-valid"
+    `('when prop "$prop" is set to an invalid value"', ({ prop }) => {
+      let props = {}
+      props[prop] = "not-valid"
+      expect(() => {
         getWrapperWithProps(props)
-        throw new Error(`Provided value "${value}" for prop "${prop}" is valid.`)
-      } catch (e) {
-        /* eslint-disable-next-line jest/no-conditional-expect */
-        expect(e).toContain(
-          `[Vue warn]: Invalid prop: custom validator check failed for prop "${prop}".`
-        )
-      }
+      }).toThrow(`[Vue warn]: Invalid prop: custom validator check failed for prop "${prop}".`)
     })
     it('when invalid value is set for prop "type"', () => {
-      try {
+      expect(() => {
         getWrapperWithProps({
           type: "not-valid",
         })
-        throw new Error(`Provided value for prop "type" is valid.`)
-      } catch (e) {
-        /* eslint-disable-next-line jest/no-conditional-expect */
-        expect(e).toContain(
-          "[Vue warn]: Unknown custom element: <not-valid> - did you register the" +
-            ' component correctly? For recursive components, make sure to provide the "name" option.'
-        )
-      }
+      }).toThrow(
+        "[Vue warn]: Unknown custom element: <not-valid> - did you register the" +
+          ' component correctly? For recursive components, make sure to provide the "name" option.'
+      )
     })
   })
   describe("oc button appearance", () => {

--- a/src/components/atoms/OcGrid/OcGrid.spec.js
+++ b/src/components/atoms/OcGrid/OcGrid.spec.js
@@ -18,17 +18,11 @@ describe("OcGrid", () => {
       }
     )
     it("should not accept invalid values", () => {
-      try {
+      expect(() => {
         getWrapper({
           gutter: "invalid",
         })
-        throw new Error(`Provided value for prop "gutter" is valid.`)
-      } catch (e) {
-        /* eslint-disable-next-line jest/no-conditional-expect */
-        expect(e).toContain(
-          `[Vue warn]: Invalid prop: custom validator check failed for prop "gutter".`
-        )
-      }
+      }).toThrow(`[Vue warn]: Invalid prop: custom validator check failed for prop "gutter".`)
     })
   })
   describe("when match prop is true", () => {

--- a/src/components/atoms/OcImage/OcImage.spec.js
+++ b/src/components/atoms/OcImage/OcImage.spec.js
@@ -23,15 +23,9 @@ describe("OcImage", () => {
     expect(wrapper.attributes("loading")).toBe(loadingType)
   })
   it("should not accept value other than (lazy & eager) for prop loading type", () => {
-    try {
+    expect(() => {
       getWrapper({ loadingType: "invalid" })
-      throw Error("value 'invalid' is valid for prop 'loadingType'.")
-    } catch (e) {
-      /* eslint-disable-next-line jest/no-conditional-expect */
-      expect(e).toContain(
-        `[Vue warn]: Invalid prop: custom validator check failed for prop "loadingType".`
-      )
-    }
+    }).toThrow(`[Vue warn]: Invalid prop: custom validator check failed for prop "loadingType".`)
   })
   describe("when alt is set", () => {
     const wrapper = getWrapper({ alt: "test alt text" })

--- a/src/components/atoms/OcNotifications/OcNotifications.spec.js
+++ b/src/components/atoms/OcNotifications/OcNotifications.spec.js
@@ -7,17 +7,11 @@ describe("OcNotifications", () => {
   }
   describe("position prop", () => {
     it("should not allow values other than top-left, top-center, top-right", () => {
-      try {
+      expect(() => {
         getWrapper({
           propsData: { position: "not-valid" },
         })
-        throw new Error(`Provided value for prop "position" is valid.`)
-      } catch (e) {
-        /* eslint-disable-next-line jest/no-conditional-expect */
-        expect(e).toContain(
-          '[Vue warn]: Invalid prop: custom validator check failed for prop "position".'
-        )
-      }
+      }).toThrow('[Vue warn]: Invalid prop: custom validator check failed for prop "position".')
     })
     it.each(["top-left", "top-center", "top-right"])(
       "it should set provided position as class for wrapper",

--- a/src/components/molecules/OcNotificationMessage/OcNotificationMessage.spec.js
+++ b/src/components/molecules/OcNotificationMessage/OcNotificationMessage.spec.js
@@ -29,18 +29,11 @@ describe("OcNotificationMessage", () => {
 
   describe("status prop", () => {
     it("should not allow values other than passive, primary, success, warning, danger", () => {
-      try {
+      expect(() => {
         getWrapper({
           status: "not-valid",
         })
-
-        throw new Error(`Provided value for prop "status" is valid.`)
-      } catch (e) {
-        /* eslint-disable-next-line jest/no-conditional-expect */
-        expect(e).toContain(
-          '[Vue warn]: Invalid prop: custom validator check failed for prop "status".'
-        )
-      }
+      }).toThrow('[Vue warn]: Invalid prop: custom validator check failed for prop "status".')
     })
 
     it.each(["passive", "primary", "success", "warning", "danger"])(

--- a/src/components/molecules/OcTextInput/OcTextInput.spec.js
+++ b/src/components/molecules/OcTextInput/OcTextInput.spec.js
@@ -116,15 +116,9 @@ describe("OcTextInput", () => {
 
   describe("type prop", () => {
     it("should only allow text, number, email and password as type", () => {
-      try {
+      expect(() => {
         getShallowWrapper({ type: "binary" })
-        throw new Error(`Provided value 'binary' for prop 'type' is valid.`)
-      } catch (e) {
-        /* eslint-disable-next-line jest/no-conditional-expect */
-        expect(e).toContain(
-          '[Vue warn]: Invalid prop: custom validator check failed for prop "type".'
-        )
-      }
+      }).toThrow('[Vue warn]: Invalid prop: custom validator check failed for prop "type".')
     })
     it.each(["text", "number", "email", "password"])(
       "should set the provided type for the input",


### PR DESCRIPTION
## Description
To assert the errors thrown, basic `try & catch` implementation was done before.
But this can be replaced using `toThrow` fn from `expect` where we can assert the expected error message thrown.
makes the test code look far better.

## Related Issue


## Motivation and Context


## How Has This Been Tested?
- locally
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
