### PR TITLE
Add grouping functionality for tables

### DIFF
--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -16,7 +16,10 @@
       <div class="oc-docs-width-medium" style="display: inline-block; width: 250px">
         <oc-select
           v-model="selected"
-          :options="Object.keys(groupingSettings.groupingFunctions)"
+          :options="[
+            ...Object.keys(groupingSettings.groupingFunctions),
+            !Object.keys(groupingSettings.groupingFunctions).includes('None') ? 'None' : '',
+          ]"
           :clearable="false"
           :searchable="false"
         />
@@ -409,6 +412,18 @@ export default {
       this.copyArray = [...result]
 
       return result
+    },
+  },
+  watch: {
+    //callback for selection of None by enabled groupingSettings
+    selected: function () {
+      if (
+        this.selected === "None" &&
+        this.groupingSettings &&
+        this.groupingSettings.groupingFunctions &&
+        this.groupingSettings.groupingFunctions["None"]
+      )
+        this.groupingSettings.groupingFunctions["None"]()
     },
   },
 

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -401,8 +401,6 @@ export default {
         result = this.groupingSettings.sortGroups[this.selected](result)
       }
 
-      this.copyArray = [...result]
-
       return result
     },
   },
@@ -416,7 +414,12 @@ export default {
 
   mounted() {
     //create copy of array to manipulate toggling
-    //this.copyArray = [...this.groupedData]
+    if (
+      this.groupingAllowed &&
+      this.groupingSettings?.showGroupingOptions &&
+      this.groupingSettings?.groupingFunctions
+    )
+      this.copyArray = [...this.groupedData]
   },
 
   methods: {

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -350,10 +350,7 @@ export default {
   },
   data() {
     return {
-      selected:
-        this.groupingSettings && this.groupingSettings.groupingBy
-          ? this.groupingSettings.groupingBy
-          : "None",
+      selected: this.groupingSettings?.groupingBy ? this.groupingSettings.groupingBy : "None",
       accordionClosed: [],
       copyArray: [],
       showMore: false,
@@ -390,8 +387,7 @@ export default {
     },
 
     groupingAllowed() {
-      return this.groupingSettings &&
-        this.groupingSettings.groupingFunctions &&
+      return this.groupingSettings?.groupingFunctions &&
         Object.keys(this.groupingSettings.groupingFunctions).length > 0
         ? true
         : false
@@ -401,11 +397,7 @@ export default {
       if (!result.length) return []
 
       //sort groups if there is a given sorting function in grouping settings
-      if (
-        this.groupingSettings &&
-        this.groupingSettings.sortGroups &&
-        this.groupingSettings.sortGroups[this.selected]
-      ) {
+      if (this.groupingSettings?.sortGroups?.[this.selected]) {
         result = this.groupingSettings.sortGroups[this.selected](result)
       }
 
@@ -417,12 +409,7 @@ export default {
   watch: {
     //callback for selection of None by enabled groupingSettings
     selected: function () {
-      if (
-        this.selected === "None" &&
-        this.groupingSettings &&
-        this.groupingSettings.groupingFunctions &&
-        this.groupingSettings.groupingFunctions["None"]
-      )
+      if (this.selected === "None" && this.groupingSettings?.groupingFunctions?.["None"])
         this.groupingSettings.groupingFunctions["None"]()
     },
   },
@@ -620,10 +607,7 @@ export default {
     createGroupedData(col, data) {
       let groups = {}
       let resultArray = []
-      if (
-        this.groupingSettings &&
-        Object.keys(this.groupingSettings.groupingFunctions).includes(col)
-      ) {
+      if (Object.keys(this.groupingSettings?.groupingFunctions).includes(col)) {
         data.forEach(row => {
           groups[this.groupingSettings.groupingFunctions[col](row)]
             ? groups[this.groupingSettings.groupingFunctions[col](row)].push(row)


### PR DESCRIPTION
## Description
Grouping as well as preview functionality for the tables, web part
Web part: [#6165](https://github.com/owncloud/web/pull/6165)

Setup is done with the property "groupingSettings" . Following settings are possible:
- groupingFunctions: Object with keys as grouping options names and functions that get a table data row and return a group name for that row. The names of the functions are used as grouping options. 

- groupingBy: must be either one of the keys in groupingFunctions or 'None'. If not set, default grouping will be 'None'.
- ShowGroupingOptions: boolean value for showing or hinding the select element with grouping options above the table.
- sortGroups: Object with keys as grouping options names and as values functions that get an array of groups and return a sorted array of groups.
     



![Screenshot from 2021-09-08 10-47-39](https://user-images.githubusercontent.com/7430156/132478203-38f7ef88-78a8-4591-a7cf-7ede8356a436.png)


## Related Issue


## Motivation and Context
UX-friendly option for better overviews of table contents



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- Tests


