### PR TITLE
Allow sort direction defaults from field

### DIFF
--- a/changelog/unreleased/change-externalize-oc-table-sorting
+++ b/changelog/unreleased/change-externalize-oc-table-sorting
@@ -4,5 +4,6 @@ We removed sorting from OcTable and added a `sort` event instead, which can be u
 This is crucial for server side sorting and handling pagination correctly.
 
 https://github.com/owncloud/owncloud-design-system/pull/1825
+https://github.com/owncloud/owncloud-design-system/pull/1839
 https://github.com/owncloud/web/pull/6136
 https://github.com/owncloud/web/issues/5687

--- a/src/mixins/sort.js
+++ b/src/mixins/sort.js
@@ -22,7 +22,7 @@ export default {
       required: false,
       default: undefined,
       validator: value => {
-        return [SORT_DIRECTION_ASC, SORT_DIRECTION_DESC].includes(value)
+        return value === undefined || [SORT_DIRECTION_ASC, SORT_DIRECTION_DESC].includes(value)
       },
     },
   },
@@ -56,10 +56,14 @@ export default {
         return
       }
 
-      // only toggle sortDir if already sorted by this column
       let sortDir = this.sortDir
-      if (field.name === this.sortBy || this.sortDir === undefined) {
+      // toggle sortDir if already sorted by this column
+      if (this.sortBy === field.name && this.sortDir !== undefined) {
         sortDir = this.sortDir === SORT_DIRECTION_DESC ? SORT_DIRECTION_ASC : SORT_DIRECTION_DESC
+      }
+      // set default sortDir of the field when sortDir not set or sortBy changed
+      if (this.sortBy !== field.name || this.sortDir === undefined) {
+        sortDir = field.sortDir || SORT_DIRECTION_DESC
       }
 
       /**


### PR DESCRIPTION
## Description
Allow a sort direction default coming from the field definition instead of just assuming it. This is important because the default sort direction for the `name` column (`ASC`)  is different from the default sort direction for the `mdate` column (`DESC`). We have no way of assuming this. Should be provided instead.

This is considered a continuation of https://github.com/owncloud/owncloud-design-system/pull/1825 so no additional changelog item provided.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated