### PR TITLE
Use multiples of 8 instead of 10 for margins and paddings

### DIFF
--- a/changelog/unreleased/enhancement-sizes
+++ b/changelog/unreleased/enhancement-sizes
@@ -1,0 +1,5 @@
+Enhancement: Sizes
+
+The size variables which define margins and paddings have been changed to use multiples of 8 instead of 10.
+
+https://github.com/owncloud/owncloud-design-system/pull/1857

--- a/src/tokens/ods/space.yaml
+++ b/src/tokens/ods/space.yaml
@@ -1,14 +1,14 @@
 ---
 space:
   xsmall:
-    value: 5px
+    value: 4px
   small:
-    value: 10px
+    value: 8px
   medium:
-    value: 20px
+    value: 16px
   large:
-    value: 30px
+    value: 24px
   xlarge:
-    value: 50px
+    value: 48px
   xxlarge:
-    value: 100px
+    value: 96px


### PR DESCRIPTION
## Description
This PR changes margins and paddings to be multiples of 8 instead of 10. Personal wish from @tbsbdr 😇 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
