### PR TITLE
Bugfix OcTooltip reactivity after beeing destroyed

### DIFF
--- a/changelog/unreleased/bugfix-tooltip-reactivity
+++ b/changelog/unreleased/bugfix-tooltip-reactivity
@@ -1,0 +1,6 @@
+Bugfix: OcTooltip isn't reactive
+
+We've fixed an issue with the OcTooltip when the tooltip
+gets hidden by reactivity and then reactivated with some value.
+
+https://github.com/owncloud/owncloud-design-system/pull/1863

--- a/src/directives/OcTooltip.js
+++ b/src/directives/OcTooltip.js
@@ -54,6 +54,7 @@ const initOrUpdate = (el, { value = {} }, { elm }) => {
 
   if (value.content !== 0 && !value.content) {
     destroy(elm.tooltip)
+    elm.tooltip = null
     return
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the issue tracker for the design system. 

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of the ownCloud design system.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Assignment: assign to self
-->

## Description
We've fixed an issue with the OcTooltip when the tooltip
gets hidden by reactivity and then reactivated with some value.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

