### PR TITLE
Switched the icon docs page to a lazy loaded OcTable and added a filter field

### DIFF
--- a/docs/components/tokens/IconList.vue
+++ b/docs/components/tokens/IconList.vue
@@ -1,41 +1,151 @@
 <template>
   <div>
-    <div v-for="(filename, index) in icons" :key="index">
-      <oc-icon :name="filename" fill-type="none" size="large" variation="passive" />
-      <oc-icon :name="filename" fill-type="none" size="large" variation="primary" />
-      <oc-icon :name="filename" fill-type="none" size="large" variation="success" />
-      <oc-icon :name="filename" fill-type="none" size="large" variation="warning" />
-      <oc-icon :name="filename" fill-type="none" size="large" variation="danger" />
-      <span
-        style="background-color: var(--oc-color-swatch-brand-default); display: inline-block"
-        class="oc-icon-l"
-      >
-        <oc-icon :name="filename" fill-type="none" size="large" variation="inverse" />
-      </span>
-      <span>{{ filename }}</span>
+    <oc-search-bar
+      v-model="query"
+      :is-filter="true"
+      :button-hidden="true"
+      label="Filter icons by name"
+      class="oc-mb"
+    />
+    <div class="oc-mb oc-px">
+      <strong>Displaying {{ filteredIcons.length }} out of {{ icons.length }} icons</strong>
     </div>
+    <oc-table :fields="fields" :data="filteredIcons">
+      <template #passive="{ item }">
+        <oc-icon
+          :name="item.filename"
+          :fill-type="item.fillType"
+          size="large"
+          variation="passive"
+        />
+      </template>
+      <template #primary="{ item }">
+        <oc-icon
+          :name="item.filename"
+          :fill-type="item.fillType"
+          size="large"
+          variation="primary"
+        />
+      </template>
+      <template #success="{ item }">
+        <oc-icon
+          :name="item.filename"
+          :fill-type="item.fillType"
+          size="large"
+          variation="success"
+        />
+      </template>
+      <template #warning="{ item }">
+        <oc-icon
+          :name="item.filename"
+          :fill-type="item.fillType"
+          size="large"
+          variation="warning"
+        />
+      </template>
+      <template #danger="{ item }">
+        <oc-icon :name="item.filename" :fill-type="item.fillType" size="large" variation="danger" />
+      </template>
+      <template #inverse="{ item }">
+        <span
+          style="background-color: var(--oc-color-swatch-brand-default); display: inline-block"
+          class="oc-icon-l"
+        >
+          <oc-icon
+            :name="item.filename"
+            :fill-type="item.fillType"
+            size="large"
+            variation="inverse"
+          />
+        </span>
+      </template>
+      <template #filename="{ item }">
+        <highlighted-text :value="item.filename" :highlighted="query" />
+      </template>
+    </oc-table>
   </div>
 </template>
 
 <script>
 import OcIcon from "../../../src/components/atoms/OcIcon/OcIcon.vue"
+import OcTable from "../../../src/components/molecules/OcTable/OcTable.vue"
+import OcSearchBar from "../../../src/components/atoms/OcSearchBar/OcSearchBar"
+import HighlightedText from "./_HighlightedText"
 const req = require.context("../../../src/assets/icons/", true, /^\.\/.*\.svg$/)
 
 /**
- * All known icons in ownCloud Design System
+ * All known icons in the ownCloud Design System
  * <p>
  *  Icons made by <a href="https://remixicon.com/">Remixicon</a> and, in the case of the `resource-type-*` icons, <a href="https://fontawesome.com/">Font Awesome</a> (available under the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/) license).
  * </p>
  */
 export default {
   name: "IconList",
-  components: { OcIcon },
+  components: { HighlightedText, OcSearchBar, OcIcon, OcTable },
   data() {
     return {
-      icons: req.keys().map(filename => {
-        return filename.split(".").slice(0, -1).join(".").substring(2)
-      }),
+      query: "",
+      icons: [],
     }
+  },
+  computed: {
+    filteredIcons() {
+      return this.icons
+        .filter(icon => icon.includes(this.query))
+        .map(icon => ({
+          filename: icon.replace("-fill", "").replace("-line", ""),
+          fillType: icon.endsWith("-fill") ? "fill" : icon.endsWith("-line") ? "line" : "none",
+        }))
+    },
+    fields() {
+      return [
+        {
+          name: "passive",
+          title: "Passive",
+          type: "slot",
+        },
+        {
+          name: "primary",
+          title: "Primary",
+          type: "slot",
+        },
+        {
+          name: "success",
+          title: "Success",
+          type: "slot",
+        },
+        {
+          name: "warning",
+          title: "Warning",
+          type: "slot",
+        },
+        {
+          name: "danger",
+          title: "Danger",
+          type: "slot",
+        },
+        {
+          name: "inverse",
+          title: "Inverse",
+          type: "slot",
+        },
+        {
+          name: "fillType",
+          title: "Fill type",
+        },
+        {
+          name: "filename",
+          title: "Icon name",
+          width: "expand",
+          type: "slot",
+        },
+      ].map(field => ({ ...field, lazy: true }))
+    },
+  },
+  mounted() {
+    this.icons = req.keys().map(filename => {
+      return filename.split(".").slice(0, -1).join(".").substring(2)
+    })
   },
 }
 </script>

--- a/docs/components/tokens/_HighlightedText.vue
+++ b/docs/components/tokens/_HighlightedText.vue
@@ -1,0 +1,92 @@
+<template>
+  <component :is="tag">
+    <template v-for="(fragments, lineIndex) in lines">
+      <template v-for="(fragment, fragmentIndex) in fragments">
+        <span
+          :is="fragment.tag"
+          :key="'line-' + lineIndex + '-fragment-' + fragmentIndex"
+          :style="{
+            display:
+              fragment.value.startsWith(' ') || fragment.value.endsWith(' ')
+                ? 'inline'
+                : 'inline-block',
+          }"
+          :class="{ 'highlighted-fragment': fragment.highlighted }"
+        >
+          {{ fragment.value }}
+        </span>
+      </template>
+      <br v-if="lineIndex < lines.length - 1" :key="'line-' + lineIndex + '-br'" />
+    </template>
+  </component>
+</template>
+
+<script>
+export default {
+  name: "HighlightedText",
+  props: {
+    tag: {
+      type: String,
+      default: "span",
+    },
+    fragmentTag: {
+      type: String,
+      default: "span",
+      validator: function (value) {
+        return ["span", "i", "em", "b", "strong"].includes(value)
+      },
+    },
+    value: {
+      type: String,
+      required: true,
+    },
+    highlighted: {
+      type: String,
+      default: null,
+    },
+  },
+  computed: {
+    lines() {
+      const regex = new RegExp("\\n")
+      const lines = this.value.split(regex)
+      return lines
+        .filter((line, index) => {
+          // note: split creates an empty first and last element. this removes those (if they are really empty)
+          return !((index === 0 || index === lines.length - 1) && !line.length)
+        })
+        .map(line => this.buildFragments(line))
+    },
+  },
+  methods: {
+    buildFragments(line) {
+      if (this.highlighted) {
+        const regex = new RegExp("(" + this.highlighted + ")", "gi")
+        const textFragments = line.split(regex)
+        if (textFragments.length > 1) {
+          return textFragments.map(fragment => {
+            return {
+              tag: this.fragmentTag,
+              value: fragment,
+              highlighted: fragment.match(regex),
+            }
+          })
+        }
+      }
+      // if not highlighting or no matches found (i.e. result = whole value), return a single fragment
+      return [
+        {
+          tag: this.fragmentTag,
+          value: line,
+          highlighted: false,
+        },
+      ]
+    },
+  },
+}
+</script>
+
+<style lang="scss">
+.highlighted-fragment {
+  background-color: yellow;
+}
+</style>


### PR DESCRIPTION
## Description
This PR switches the icon docs page to a lazy loaded OcTable and adds a filter field.

## Motivation and Context
Make the icon docs page better usable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
