### PR TITLE
Stop click propagation on parent folder clicks in OcResource

### DIFF
--- a/changelog/unreleased/enhancement-parent-folder-distinguish-files
+++ b/changelog/unreleased/enhancement-parent-folder-distinguish-files
@@ -5,3 +5,4 @@ in order to distinguish files better
 
 https://github.com/owncloud/web/issues/5953
 https://github.com/owncloud/owncloud-design-system/pull/1860
+https://github.com/owncloud/owncloud-design-system/pull/1871

--- a/src/components/organisms/OcResource/OcResource.vue
+++ b/src/components/organisms/OcResource/OcResource.vue
@@ -50,6 +50,8 @@
           :to="parentFolderLinkPath"
           :style="parentFolderStyle"
           class="parent-folder"
+          @click.stop
+          @click.native.stop
         >
           <oc-icon name="folder-2" size="small" fill-type="line" />
           <span class="text" v-text="parentFolder" />


### PR DESCRIPTION
## Description
Stop click propagation on parent folder clicks in OcResource. This is needed because otherwise the click handler of the parent fires as well (if it has one).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
