### PR TITLE
Fix document type icon heights in relation to folder icon

### DIFF
--- a/changelog/unreleased/enhancement-redesign-filetype-icons
+++ b/changelog/unreleased/enhancement-redesign-filetype-icons
@@ -5,3 +5,4 @@ We've added a new OcResourceIcon component that is themable.
 
 https://github.com/owncloud/web/issues/6278
 https://github.com/owncloud/owncloud-design-system/pull/1900
+https://github.com/owncloud/owncloud-design-system/pull/1924

--- a/src/components/atoms/OcResourceIcon/OcResourceIcon.vue
+++ b/src/components/atoms/OcResourceIcon/OcResourceIcon.vue
@@ -1,5 +1,14 @@
 <template>
-  <oc-icon :key="`resource-icon-${iconName}`" :name="iconName" :color="iconColor" :size="size" />
+  <oc-icon
+    :key="`resource-icon-${iconName}`"
+    :name="iconName"
+    :color="iconColor"
+    :size="size"
+    :class="[
+      'oc-resource-icon',
+      { 'oc-resource-icon-file': !isFolder, 'oc-resource-icon-folder': isFolder },
+    ]"
+  />
 </template>
 
 <script>
@@ -49,7 +58,7 @@ export default {
       return color ? color : defaultFallbackIconColor
     },
     isFolder() {
-      return this.resource.type === "folder"
+      return this.resource.isFolder
     },
     extension() {
       return this.resource.extension.toLowerCase()
@@ -57,3 +66,13 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.oc-resource-icon {
+  display: inline-flex;
+  align-items: center;
+  &-file svg {
+    height: 75%;
+  }
+}
+</style>

--- a/src/components/organisms/OcResource/OcResource.spec.js
+++ b/src/components/organisms/OcResource/OcResource.spec.js
@@ -8,6 +8,7 @@ const fileResource = {
   thumbnail: "https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg",
   indicators: [],
   type: "file",
+  isFolder: false,
   extension: "jpg",
 }
 const folderResource = {
@@ -15,6 +16,7 @@ const folderResource = {
   path: "",
   indicators: [],
   type: "folder",
+  isFolder: true,
 }
 
 describe("OcResource", () => {


### PR DESCRIPTION
## Description
Enforce the heights of folder- and document-resource-icons to be the same so that document type icons don't have a larger appearance anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
