### PR TITLE
Fix drop shadow in OcDrop

### DIFF
--- a/changelog/unreleased/bugfix-oc-drop-shadow
+++ b/changelog/unreleased/bugfix-oc-drop-shadow
@@ -3,3 +3,4 @@ Bugfix: Missing OcDrop shadow
 In certain situations, other DOM elements made the OcDrop shadow invisible. This has been resolved.
 
 https://github.com/owncloud/owncloud-design-system/pull/1926
+https://github.com/owncloud/owncloud-design-system/pull/1931

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -2,8 +2,7 @@
   <div
     :id="dropId"
     ref="drop"
-    class="oc-drop oc-box-shadow-medium oc-drop-rounded"
-    style="box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.12)"
+    class="oc-drop oc-box-shadow-medium oc-rounded"
     @click="$_ocDrop_close"
   >
     <div
@@ -206,7 +205,8 @@ export default {
   line-height: inherit;
 
   .tippy-content {
-    padding: var(--oc-space-xsmall);
+    // note: needed so that the box shadow from `oc-box-shadow-medium` doesn't get suppressed
+    padding: 8px;
   }
 }
 

--- a/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
+++ b/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
@@ -32,9 +32,8 @@ exports[`OcDrop tippy renders tippy 1`] = `
         style="transition-duration: 300ms;"
       >
         <div
-          class="oc-drop oc-box-shadow-medium oc-drop-rounded"
+          class="oc-drop oc-box-shadow-medium oc-rounded"
           id="oc-drop-15"
-          style="box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.12);"
         >
           <div
             class="oc-card oc-card-body oc-rounded oc-background-highlight oc-p-m"
@@ -79,9 +78,8 @@ exports[`OcDrop tippy renders tippy 2`] = `
         style="transition-duration: 250ms;"
       >
         <div
-          class="oc-drop oc-box-shadow-medium oc-drop-rounded"
+          class="oc-drop oc-box-shadow-medium oc-rounded"
           id="oc-drop-15"
-          style="box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.12);"
         >
           <div
             class="oc-card oc-card-body oc-rounded oc-background-highlight oc-p-m"
@@ -127,9 +125,8 @@ exports[`OcDrop tippy renders tippy 3`] = `
         style="transition-duration: 300ms;"
       >
         <div
-          class="oc-drop oc-box-shadow-medium oc-drop-rounded"
+          class="oc-drop oc-box-shadow-medium oc-rounded"
           id="oc-drop-15"
-          style="box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.12);"
         >
           <div
             class="oc-card oc-card-body oc-rounded oc-background-highlight oc-p-m"

--- a/src/styles/theme/helper.scss
+++ b/src/styles/theme/helper.scss
@@ -29,7 +29,7 @@
 }
 
 .oc-box-shadow-medium {
-  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
+  box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.12);
 }
 
 .oc-overflow-auto {


### PR DESCRIPTION
## Description
Changes the drop shadow to emulate a light source from the top left. Fix sharp edges without box shadow around the rounded corners of the drop (class name was wrong, `oc-drop-rounded` instead of `oc-rounded`). Also removed a hardcoded box shadow that was overwriting the box shadow class.

## Screenshots (if appropriate):

### before
<img width="345" alt="Screenshot 2022-02-03 at 23 24 03" src="https://user-images.githubusercontent.com/3532843/152440173-d55e1c36-b046-4aa8-b0c4-e707e71d3837.png">
<img width="368" alt="Screenshot 2022-02-03 at 23 24 13" src="https://user-images.githubusercontent.com/3532843/152440179-de7a291a-9946-4667-915f-8163f9646d9f.png">


### after
<img width="338" alt="Screenshot 2022-02-03 at 23 28 37" src="https://user-images.githubusercontent.com/3532843/152440217-10567a0d-ba84-445e-ad46-b9a958b5bb02.png">
<img width="343" alt="Screenshot 2022-02-03 at 23 28 46" src="https://user-images.githubusercontent.com/3532843/152440221-e6398d01-fa71-4565-8d88-16aeaaf6cf5f.png">



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
