### PR TITLE
Clean up component release info

### DIFF
--- a/src/components/atoms/OcAvatarItem/OcAvatarItem.vue
+++ b/src/components/atoms/OcAvatarItem/OcAvatarItem.vue
@@ -17,7 +17,7 @@ import OcIcon from "../OcIcon/OcIcon.vue"
 
 export default {
   name: "OcAvatarItem",
-  status: "review",
+  status: "ready",
   release: "10.0.0",
   components: {
     OcIcon,

--- a/src/components/atoms/OcList/OcList.vue
+++ b/src/components/atoms/OcList/OcList.vue
@@ -13,7 +13,7 @@
 export default {
   name: "OcList",
   status: "ready",
-  released: "unreleased",
+  release: "12.0.0",
   props: {
     raw: {
       type: Boolean,

--- a/src/components/atoms/OcResourceIcon/OcResourceIcon.vue
+++ b/src/components/atoms/OcResourceIcon/OcResourceIcon.vue
@@ -23,7 +23,7 @@ const defaultFallbackIcon = "file"
 
 export default {
   name: "OcResourceIcon",
-  status: "unreleased",
+  status: "ready",
   release: "12.0.0",
   components: { OcIcon },
   props: {

--- a/src/components/atoms/OcResourceName/OcResourceName.vue
+++ b/src/components/atoms/OcResourceName/OcResourceName.vue
@@ -17,8 +17,7 @@
 export default {
   name: "OcResourceName",
   status: "ready",
-  released: "2.1.0",
-
+  release: "2.1.0",
   props: {
     /**
      * The name of the resource

--- a/src/components/atoms/OcResourceSize/OcResourceSize.vue
+++ b/src/components/atoms/OcResourceSize/OcResourceSize.vue
@@ -11,8 +11,7 @@ import filesize from "filesize"
 export default {
   name: "OcResourceSize",
   status: "ready",
-  released: "2.1.0",
-
+  release: "2.1.0",
   props: {
     /**
      * Number of bytes to display as a reasonable resource size string.

--- a/src/components/atoms/_OcGhostElement/_OcGhostElement.vue
+++ b/src/components/atoms/_OcGhostElement/_OcGhostElement.vue
@@ -11,6 +11,8 @@
  */
 export default {
   name: "OcGhostElement",
+  status: "ready",
+  release: "11.2.0",
   props: {
     previewItems: {
       type: Array,

--- a/src/components/molecules/OcAvatarFederated/OcAvatarFederated.vue
+++ b/src/components/molecules/OcAvatarFederated/OcAvatarFederated.vue
@@ -15,7 +15,7 @@ import OcAvatarItem from "../../atoms/OcAvatarItem/OcAvatarItem.vue"
 
 export default {
   name: "OcAvatarFederated",
-  status: "review",
+  status: "ready",
   release: "10.0.0",
   components: { OcAvatarItem },
 

--- a/src/components/molecules/OcAvatarGroup/OcAvatarGroup.vue
+++ b/src/components/molecules/OcAvatarGroup/OcAvatarGroup.vue
@@ -13,7 +13,7 @@ import OcAvatarItem from "../../atoms/OcAvatarItem/OcAvatarItem.vue"
 
 export default {
   name: "OcAvatarGroup",
-  status: "review",
+  status: "ready",
   release: "10.0.0",
   components: { OcAvatarItem },
 

--- a/src/components/molecules/OcAvatarGuest/OcAvatarGuest.vue
+++ b/src/components/molecules/OcAvatarGuest/OcAvatarGuest.vue
@@ -15,7 +15,7 @@ import OcAvatarItem from "../../atoms/OcAvatarItem/OcAvatarItem.vue"
 
 export default {
   name: "OcAvatarGuest",
-  status: "review",
+  status: "ready",
   release: "10.0.0",
   components: { OcAvatarItem },
 

--- a/src/components/molecules/OcLogo/OcLogo.vue
+++ b/src/components/molecules/OcLogo/OcLogo.vue
@@ -14,7 +14,7 @@ import OcImg from "../../atoms/OcImage/OcImage.vue"
 export default {
   name: "OcLogo",
   status: "ready",
-  release: "unreleased",
+  release: "7.3.0",
   components: { OcImg },
 
   props: {


### PR DESCRIPTION
Some components on https://owncloud.design/ are being listed as either `In review` or with missing release info. This PR fixes it (couldn't find all the relevant release info for e.g. OcList though)