### PR TITLE
Only allow hover in OcTable when enabled

### DIFF
--- a/changelog/unreleased/enhancement-redesign-filestable-related-components
+++ b/changelog/unreleased/enhancement-redesign-filestable-related-components
@@ -4,4 +4,5 @@ We've adjusted OcTable, OcResource, OcDrop and OcCheckbox
 to fit the redesign.
 
 https://github.com/owncloud/owncloud-design-system/pull/1958
+https://github.com/owncloud/owncloud-design-system/pull/1978
 https://github.com/owncloud/web/issues/6207

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -475,16 +475,12 @@ export default {
     height: var(--oc-size-height-table-row);
   }
 
-  tr:hover {
-    background-color: var(--oc-color-background-hover);
-  }
-
   tr + tr {
     border-top: 1px solid var(--oc-color-border);
   }
 
   &-hover tr:not(&-footer-row):hover {
-    background-color: var(--oc-color-background-accentuate);
+    background-color: var(--oc-color-background-hover);
   }
 
   &-highlighted {


### PR DESCRIPTION
Seems to have gone unnoticed in https://github.com/owncloud/owncloud-design-system/pull/1958, but suddenly we had a hover on the OcTable footer. This kinda reverts the changes to only allow hover on none-footer-cells and when hovering is enabled for the component via its props