### PR TITLE
extend modal focus-trap

### DIFF
--- a/changelog/unreleased/enhancement-modal-focus-trap
+++ b/changelog/unreleased/enhancement-modal-focus-trap
@@ -1,0 +1,5 @@
+Enhancement: Extend modal focus-trap functionality
+
+We've added the option to define which child element should be focused initially.
+
+https://github.com/owncloud/owncloud-design-system/pull/1987

--- a/src/components/organisms/OcModal/OcModal.vue
+++ b/src/components/organisms/OcModal/OcModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="oc-modal-background" aria-labelledby="oc-modal-title">
-    <focus-trap :active="true" :initial-focus="getInitialFocusRef">
+    <focus-trap :active="true" :initial-focus="focusTrapInitial">
       <div
         ref="ocModal"
         :class="classes"
@@ -230,6 +230,15 @@ export default {
       required: false,
       default: false,
     },
+    /**
+     * Overwrite default focused element
+     * Can be `#id, .class`.
+     */
+    focusTrapInitial: {
+      type: String,
+      required: false,
+      default: null,
+    },
   },
   data() {
     return {
@@ -277,10 +286,7 @@ export default {
       this.userInputValue = value
     },
     getInitialFocusRef() {
-      if (this.hasInput) {
-        return this.$refs.ocModalInput
-      }
-      return this.$refs.ocModal
+      return this.focusTrapInitial || this.$refs.ocModalInput || this.$refs.ocModal
     },
   },
 }
@@ -430,32 +436,16 @@ export default {
   </oc-modal>
 ```
 
-## Focus trap
-When the modal is displayed, it should not be possible to reach any element outside of the modal. To protect this also for keyboard navigation, focus trap should be activate via prop `focusTrapActive`.
-If activated, only focusable elements within the modal are reachable via keyboard navigation.
-
 ```js
-<template>
-  <div>
-    <oc-button @click="active = !active">Toggle focus trap</oc-button>
-    <p>Focus trap active: {{ active }}</p>
-    <oc-modal
-      icon="info"
-      title="Accept terms of use"
-      message="Do you accept our terms of use?"
-      button-cancel-text="Decline"
-      button-confirm-text="Accept"
-      class="oc-mb-l oc-position-relative"
-      :focus-trap-active="active"
-    />
-  </div>
-</template>
-<script>
-export default {
-  data: () => ({
-    active: false
-  })
-}
-</script>
+<div>
+	<oc-modal
+			icon="info"
+			title="Accept terms of use"
+			message="Do you accept our terms of use?"
+			button-cancel-text="Decline"
+			button-confirm-text="Accept"
+			class="oc-mb-l oc-position-relative"
+	/>
+</div>
 ```
 </docs>

--- a/src/components/organisms/OcModal/__snapshots__/OcModal.spec.js.snap
+++ b/src/components/organisms/OcModal/__snapshots__/OcModal.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`OcModal displays input 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->
@@ -22,7 +22,7 @@ exports[`OcModal displays input 1`] = `
 
 exports[`OcModal hides icon if not specified 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->
@@ -42,7 +42,7 @@ exports[`OcModal hides icon if not specified 1`] = `
 
 exports[`OcModal matches snapshot 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <oc-icon-stub name="info" filltype="fill" accessiblelabel="" type="span" size="medium" variation="passive" color=""></oc-icon-stub>
@@ -62,7 +62,7 @@ exports[`OcModal matches snapshot 1`] = `
 
 exports[`OcModal overrides props message with slot 1`] = `
 <div aria-labelledby="oc-modal-title" class="oc-modal-background">
-  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true" initialfocus="[Function]">
+  <focus-trap-stub active="true" escapedeactivates="true" returnfocusondeactivate="true" allowoutsideclick="true">
     <div tabindex="0" role="dialog" aria-modal="true" class="oc-modal oc-modal-passive">
       <div class="oc-modal-title">
         <!---->


### PR DESCRIPTION
## Description
* add modal option to define which child element should be focused initially

## Related Issue
- https://github.com/owncloud/web/pull/6410