### PR TITLE
OcButton: Change default type of buttons to button

### DIFF
--- a/changelog/unreleased/change-ocbutton-default-type
+++ b/changelog/unreleased/change-ocbutton-default-type
@@ -1,0 +1,9 @@
+Change: Default type of OcButton
+
+We've changed the default type of buttons rendered by `OcButton` to `button`.
+Browsers otherwise assume they are of type `submit` which leads to very unexpected
+behavior in forms, especially as we use `OcButton` in a lot of (not so obvious) places
+for a11y reasons.
+
+
+https://github.com/owncloud/owncloud-design-system/pull/2009

--- a/src/components/atoms/OcButton/OcButton.vue
+++ b/src/components/atoms/OcButton/OcButton.vue
@@ -2,7 +2,6 @@
   <component
     :is="type"
     v-bind="additionalAttributes"
-    :type="submit"
     :aria-label="ariaLabel"
     :class="$_ocButton_buttonClass"
     :disabled="disabled"
@@ -73,13 +72,13 @@ export default {
       default: null,
     },
     /**
-     * Set the button’s type to “submit”.
+     * Set the button’s type ("submit", "button" or "reset").
      */
     submit: {
       type: String,
-      default: null,
+      default: "button",
       validator: value => {
-        return value.match(/(null|submit)/)
+        return value.match(/(null|button|submit|reset)/)
       },
     },
     /**
@@ -156,6 +155,7 @@ export default {
       return {
         ...(this.href && { href: this.href }),
         ...(this.to && { to: this.to }),
+        ...(this.type === "button" && { type: this.submit }),
       }
     },
 

--- a/src/components/molecules/OcAlert/__snapshots__/OcAlert.spec.js.snap
+++ b/src/components/molecules/OcAlert/__snapshots__/OcAlert.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`OcAlert displays correct message 1`] = `
 <div class="oc-alert oc-alert-passive">
-  <oc-button-stub type="button" size="medium" arialabel="Close alert" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="oc-alert-close">
+  <oc-button-stub type="button" size="medium" arialabel="Close alert" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="oc-alert-close">
     <oc-icon-stub name="close" filltype="fill" accessiblelabel="" type="span" size="small" variation="inverse" color=""></oc-icon-stub>
   </oc-button-stub>
   <p class="slot-message">Test message</p>
@@ -18,7 +18,7 @@ exports[`OcAlert hides the close button if disabled 1`] = `
 
 exports[`OcAlert sets correct variation 1`] = `
 <div class="oc-alert oc-alert-primary">
-  <oc-button-stub type="button" size="medium" arialabel="Close alert" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="oc-alert-close">
+  <oc-button-stub type="button" size="medium" arialabel="Close alert" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium" class="oc-alert-close">
     <oc-icon-stub name="close" filltype="fill" accessiblelabel="" type="span" size="small" variation="inverse" color=""></oc-icon-stub>
   </oc-button-stub>
   <p class="slot-message">Test message</p>

--- a/src/components/molecules/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.js.snap
+++ b/src/components/molecules/OcBreadcrumb/__snapshots__/OcBreadcrumb.spec.js.snap
@@ -10,7 +10,7 @@ exports[`OcBreadcrumb displays all items 1`] = `
     </li>
     <li class="oc-breadcrumb-list-item">
       <!---->
-      <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="center" gapsize="medium"><span>Subfolder</span></oc-button-stub>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium"><span>Subfolder</span></oc-button-stub>
       <!---->
     </li>
     <li class="oc-breadcrumb-list-item">
@@ -34,7 +34,7 @@ exports[`OcBreadcrumb displays all items 1`] = `
           </router-link-stub>
         </li>
         <li>
-          <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="left" gapsize="medium">
+          <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="left" gapsize="medium">
             Subfolder
           </oc-button-stub>
         </li>
@@ -59,7 +59,7 @@ exports[`OcBreadcrumb sets correct variation 1`] = `
     </li>
     <li class="oc-breadcrumb-list-item">
       <!---->
-      <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="center" gapsize="medium"><span>Subfolder</span></oc-button-stub>
+      <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="center" gapsize="medium"><span>Subfolder</span></oc-button-stub>
       <!---->
     </li>
     <li class="oc-breadcrumb-list-item">
@@ -83,7 +83,7 @@ exports[`OcBreadcrumb sets correct variation 1`] = `
           </router-link-stub>
         </li>
         <li>
-          <oc-button-stub type="button" size="medium" variation="passive" appearance="raw" justifycontent="left" gapsize="medium">
+          <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="raw" justifycontent="left" gapsize="medium">
             Subfolder
           </oc-button-stub>
         </li>

--- a/src/components/organisms/OcModal/__snapshots__/OcModal.spec.js.snap
+++ b/src/components/organisms/OcModal/__snapshots__/OcModal.spec.js.snap
@@ -11,8 +11,8 @@ exports[`OcModal displays input 1`] = `
       <div class="oc-modal-body">
         <oc-text-input-stub id="oc-textinput-1" type="text" value="New folder" clearbuttonaccessiblelabel="" label="Folder name" fixmessageline="true" class="oc-modal-body-input"></oc-text-input-stub>
         <div class="oc-modal-body-actions oc-flex oc-flex-right">
-          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-          <oc-button-stub type="button" size="medium" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
         </div>
       </div>
     </div>
@@ -31,8 +31,8 @@ exports[`OcModal hides icon if not specified 1`] = `
       <div class="oc-modal-body">
         <p class="oc-modal-body-message">Example message</p>
         <div class="oc-modal-body-actions oc-flex oc-flex-right">
-          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-          <oc-button-stub type="button" size="medium" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
         </div>
       </div>
     </div>
@@ -51,8 +51,8 @@ exports[`OcModal matches snapshot 1`] = `
       <div class="oc-modal-body">
         <p class="oc-modal-body-message">Example message</p>
         <div class="oc-modal-body-actions oc-flex oc-flex-right">
-          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-          <oc-button-stub type="button" size="medium" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
         </div>
       </div>
     </div>
@@ -73,8 +73,8 @@ exports[`OcModal overrides props message with slot 1`] = `
           <p>Slot message</p>
         </div>
         <div class="oc-modal-body-actions oc-flex oc-flex-right">
-          <oc-button-stub type="button" size="medium" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
-          <oc-button-stub type="button" size="medium" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="passive" appearance="outline" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-cancel">Cancel</oc-button-stub>
+          <oc-button-stub type="button" size="medium" submit="button" variation="primary" appearance="filled" justifycontent="center" gapsize="medium" class="oc-modal-body-actions-confirm oc-ml-s">Confirm</oc-button-stub>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the issue tracker for the design system. 

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next major version of the ownCloud design system.

We will carefully discuss if your change can or has to be backported to stable branches.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" in case the PR still has open tasks
- Assignment: assign to self
-->

## Description
This changes the default type of `OcButton` to `button`.
The default type for `<button>` elements is `submit`. As we use it all over the place now for a11y reasons, we have lots and lots of submit buttons everywhere, which is most likely not what we want.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Could not find an open ticket for this issue.

## Motivation and Context
I recently noticed that pressing enter in one of the text inputs in the public link editing view opened the datepicker instead of saving the link:

https://user-images.githubusercontent.com/448487/157119392-20d2e849-3124-408f-a4e6-88af05878c40.mp4

It was @fschade  (💖 ) who pointed me towards the root of the issue:
pressing enter submits the form, which automatically clicks the first (at least in chromium) button which is not of type "button". In this case this happened to be the button that opens the datepicker.
Now I would argue that more often than not buttons should not behave as submit buttons and we should instead mark submit buttons explicitly. As there are only a few occurences of `<form` in oC Web, this change should not be too invasive...



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...




## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
