### PR TITLE
Ad OcResource parentfolder name prop

### DIFF
--- a/changelog/unreleased/enhancement-configurable-resource-parentfolder
+++ b/changelog/unreleased/enhancement-configurable-resource-parentfolder
@@ -1,0 +1,7 @@
+Enhancement: Configurable OcResource parentfolder name
+
+We've added a `parent-folder-name-default` property to the OcResource component.
+Before, an empty parent resulted in a hardcoded "All files and folders" which 
+becomes misleading with the introduction of spaces in oCIS.
+
+https://github.com/owncloud/owncloud-design-system/pull/2029

--- a/src/components/organisms/OcResource/OcResource.spec.js
+++ b/src/components/organisms/OcResource/OcResource.spec.js
@@ -20,7 +20,7 @@ const folderResource = {
   type: "folder",
   isFolder: true,
 }
-const fileResourceWithParentFoldername = {
+const fileResourceWithoutParentFoldername = {
   name: "example.pdf",
   path: "example.pdf",
   type: "file",
@@ -94,10 +94,10 @@ describe("OcResource", () => {
     expect(wrapper.find(".parent-folder").attributes("style")).toEqual("cursor: default;")
   })
 
-  it("displays parent folder name default if given", () => {
+  it("displays parent folder name default if calculated name is empty", () => {
     const wrapper = mount(Resource, {
       propsData: {
-        resource: fileResourceWithParentFoldername,
+        resource: fileResourceWithoutParentFoldername,
         isPathDisplayed: true,
         parentFolderNameDefault: "Example parent folder name",
       },

--- a/src/components/organisms/OcResource/OcResource.spec.js
+++ b/src/components/organisms/OcResource/OcResource.spec.js
@@ -10,7 +10,6 @@ const fileResource = {
   name: "forest.jpg",
   path: "nature/forest.jpg",
   thumbnail: "https://cdn.pixabay.com/photo/2015/09/09/16/05/forest-931706_960_720.jpg",
-  indicators: [],
   type: "file",
   isFolder: false,
   extension: "jpg",
@@ -18,9 +17,15 @@ const fileResource = {
 const folderResource = {
   name: "Documents",
   path: "",
-  indicators: [],
   type: "folder",
   isFolder: true,
+}
+const fileResourceWithParentFoldername = {
+  name: "example.pdf",
+  path: "example.pdf",
+  type: "file",
+  isFolder: false,
+  extension: "pdf",
 }
 
 describe("OcResource", () => {
@@ -87,5 +92,18 @@ describe("OcResource", () => {
 
     expect(wrapper.find(".parent-folder").find("a").exists()).toBeFalsy()
     expect(wrapper.find(".parent-folder").attributes("style")).toEqual("cursor: default;")
+  })
+
+  it("displays parent folder name default if given", () => {
+    const wrapper = mount(Resource, {
+      propsData: {
+        resource: fileResourceWithParentFoldername,
+        isPathDisplayed: true,
+        parentFolderNameDefault: "Example parent folder name",
+      },
+      stubs,
+    })
+
+    expect(wrapper).toMatchSnapshot()
   })
 })

--- a/src/components/organisms/OcResource/OcResource.vue
+++ b/src/components/organisms/OcResource/OcResource.vue
@@ -108,7 +108,7 @@ export default {
       required: true,
     },
     /**
-     * The
+     * The resource parent folder name to be displayed
      */
     parentFolderNameDefault: {
       type: String,

--- a/src/components/organisms/OcResource/OcResource.vue
+++ b/src/components/organisms/OcResource/OcResource.vue
@@ -108,6 +108,14 @@ export default {
       required: true,
     },
     /**
+     * The
+     */
+    parentFolderNameDefault: {
+      type: String,
+      required: false,
+      default: "",
+    },
+    /**
      * Asserts whether the resource path should be displayed
      */
     isPathDisplayed: {
@@ -139,7 +147,7 @@ export default {
 
     parentFolder() {
       const folder = path.basename(path.dirname(this.resource.path)).replace(".", "")
-      return folder !== "" ? folder : this.$gettext("All files and folders")
+      return folder !== "" ? folder : this.parentFolderNameDefault
     },
 
     parentFolderStyle() {
@@ -236,10 +244,11 @@ export default {
   ```js
     <template>
       <div>
-        <oc-resource :resource="documents" :parent-folder-link="parentFolderLink" class="oc-mb" />
-        <oc-resource :resource="notes" :isPathDisplayed="true" class="oc-mb" />
-        <oc-resource :resource="notes" :isResourceClickable="false" class="oc-mb" />
-        <oc-resource :resource="forest" :isPathDisplayed="true" />
+        <oc-resource :resource="documents" parent-folder-link="parentFolderLink" class="oc-mb" />
+        <oc-resource :resource="notes" is-path-displayed="true" class="oc-mb" />
+        <oc-resource :resource="notes" is-resource-clickable="false" class="oc-mb" />
+        <oc-resource :resource="forest" is-path-displayed="true" />
+        <oc-resource :resource="something" is-path-displayed="true" parent-folder-name-default="Example parent folder"  />
       </div>
     </template>
     <script>
@@ -269,6 +278,18 @@ export default {
             name: "forest-image-with-filename-with-a-lot-of-characters.jpg",
             extension: "jpg",
             path: "images/nature/forest-image-with-filename-with-a-lot-of-characters.jpg",
+            thumbnail: "https://picsum.photos/200/300",
+            indicators: [],
+            type: "file",
+            isFolder: false,
+            opensInNewWindow: true,
+          }
+        },
+        something() {
+          return {
+            name: "another-image.jpg",
+            extension: "jpg",
+            path: "another-image.jpg",
             thumbnail: "https://picsum.photos/200/300",
             indicators: [],
             type: "file",

--- a/src/components/organisms/OcResource/__snapshots__/OcResource.spec.js.snap
+++ b/src/components/organisms/OcResource/__snapshots__/OcResource.spec.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OcResource displays parent folder name default if given 1`] = `
+<div class="oc-resource oc-text-overflow"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-l oc-icon-passive oc-resource-icon oc-resource-icon-file"><!----></span></button>
+  <div class="oc-resource-details oc-text-overflow"><button type="button" class="oc-text-overflow oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw">
+      <!----> <span data-test-resource-path="example.pdf" data-test-resource-name="example.pdf" data-test-resource-type="file" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">example</span></span> <span class="oc-resource-extension">.pdf</span></span>
+    </button>
+    <div class="oc-resource-indicators"><span class="parent-folder" style="cursor: default;"><span class="oc-icon oc-icon-s oc-icon-passive"><!----></span> <span class="text">Example parent folder name</span></span></div>
+  </div>
+</div>
+`;

--- a/src/components/organisms/OcResource/__snapshots__/OcResource.spec.js.snap
+++ b/src/components/organisms/OcResource/__snapshots__/OcResource.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcResource displays parent folder name default if given 1`] = `
+exports[`OcResource displays parent folder name default if calculated name is empty 1`] = `
 <div class="oc-resource oc-text-overflow"><button type="button" class="oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw"><span class="oc-icon oc-icon-l oc-icon-passive oc-resource-icon oc-resource-icon-file"><!----></span></button>
   <div class="oc-resource-details oc-text-overflow"><button type="button" class="oc-text-overflow oc-button oc-rounded oc-button-m oc-button-justify-content-left oc-button-gap-undefined oc-button-passive oc-button-passive-raw">
       <!----> <span data-test-resource-path="example.pdf" data-test-resource-name="example.pdf" data-test-resource-type="file" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">example</span></span> <span class="oc-resource-extension">.pdf</span></span>


### PR DESCRIPTION
Makes default parent folder name configurable for `web` to differentiate between "All files" (former fallback, needed for OC10) and "Personal/{spaceName}" in oCIS