### PR TITLE
Make StatusIndicators properly round again

### DIFF
--- a/changelog/unreleased/enhancement-redesign-status-indicators
+++ b/changelog/unreleased/enhancement-redesign-status-indicators
@@ -6,3 +6,4 @@ in a separate column in the ResourceTable in web
 https://github.com/owncloud/web/issues/5976
 https://github.com/owncloud/web/pull/6552
 https://github.com/owncloud/owncloud-design-system/pull/2014
+https://github.com/owncloud/owncloud-design-system/pull/2035

--- a/src/components/molecules/OcStatusIndicators/OcStatusIndicators.vue
+++ b/src/components/molecules/OcStatusIndicators/OcStatusIndicators.vue
@@ -120,7 +120,7 @@ export default {
   display: flex;
   justify-content: flex-end;
   &-indicator {
-    border-radius: 99px;
+    border-radius: 50% !important;
   }
 }
 </style>


### PR DESCRIPTION
## Description
Recent changes to OcButton styling affected the OcStatusIndicator border-radius. It's now back to a "full circle"