### PR TITLE
Update gradient button text&border&icon color

### DIFF
--- a/changelog/unreleased/enhancement-primary-button-gradient
+++ b/changelog/unreleased/enhancement-primary-button-gradient
@@ -4,3 +4,4 @@ We've updated the OcButton to use the gradient background color when used in its
 
 https://github.com/owncloud/owncloud-design-system/issues/1952
 https://github.com/owncloud/owncloud-design-system/pull/2036
+https://github.com/owncloud/owncloud-design-system/pull/2038

--- a/src/components/atoms/OcButton/OcButton.vue
+++ b/src/components/atoms/OcButton/OcButton.vue
@@ -349,6 +349,18 @@ export default {
     );
     &-filled {
       @extend .oc-background-primary-gradient;
+      color: var(--oc-color-swatch-inverse-default) !important;
+
+      border: 1px solid
+        linear-gradient(
+          90deg,
+          var(--oc-color-swatch-primary-muted) 0%,
+          var(--oc-color-swatch-primary-gradient) 100%
+        ) !important;
+
+      span > svg {
+        fill: var(--oc-color-swatch-inverse-default) !important;
+      }
     }
   }
 


### PR DESCRIPTION
After using #2036 in `web`, it became apparent that the color/icon/border color of the (gradient-filled) primary button wasn't applied correctly in dark mode