### PR TITLE
export package members

### DIFF
--- a/changelog/unreleased/enhancement-export-members
+++ b/changelog/unreleased/enhancement-export-members
@@ -1,0 +1,6 @@
+Enhancement: Export package members
+
+Add exports for `composables`, `utils`, `components`, `directives`, `helpers` and `mixins`.
+Start using them via `import { composables, utils, ... } from 'owncloud-design-system'`.
+
+https://github.com/owncloud/owncloud-design-system/pull/2048

--- a/src/system.js
+++ b/src/system.js
@@ -6,10 +6,27 @@
  */
 
 import "./styles/styles.scss"
+import { getSizeClass } from "./utils/sizeClasses.js"
 
-// Define contexts to require
-const componentsContext = require.context("./components/", true, /\.vue$/)
-const directivesContext = require.context("./directives/", true, /\.js$/)
+const exportContext = ctx =>
+  ctx.keys().reduce((acc, key) => {
+    const exp = ctx(key).default || ctx(key)
+    const name =
+      exp.name ||
+      key
+        .split("/")
+        .pop()
+        .replace(/\.[^/.]+$/, "")
+    acc[name] = exp
+    return acc
+  }, {})
+
+export * as composables from "./composables"
+export const utils = { getSizeClass }
+export const components = exportContext(require.context("./components/", true, /\.vue$/))
+export const directives = exportContext(require.context("./directives/", true, /\.js$/))
+export const helpers = exportContext(require.context("./helpers/", true, /\.js$/))
+export const mixins = exportContext(require.context("./mixins/", true, /\.js$/))
 
 const initializeCustomProps = (tokens = [], prefix) => {
   for (const param in tokens) {
@@ -27,16 +44,8 @@ const System = {
     initializeCustomProps(themeOptions?.sizes, "size-")
     initializeCustomProps(themeOptions?.spacing, "space-")
 
-    componentsContext
-      .keys()
-      .forEach(key =>
-        Vue.component(componentsContext(key).default.name, componentsContext(key).default)
-      )
-    directivesContext
-      .keys()
-      .forEach(key =>
-        Vue.directive(directivesContext(key).default.name, directivesContext(key).default)
-      )
+    Object.keys(components).forEach(name => Vue.component(name, components[name]))
+    Object.keys(directives).forEach(name => Vue.directive(name, directives[name]))
   },
 }
 


### PR DESCRIPTION
## Description
ODS currently only add its members to vu by using `vue.use`,
it's currently not possible to create a custom component in the consuming app and re-use mixins from ODS.

This pr exposes those and makes it possible to import them e.g. `import { mixins, utils, helpers } from 'owncloud-design-system'`

## Motivation and Context
We will introduce a new poc package in web which adds an experimental fork of `oc-table` to support column grouping.
This implementation needs certain parts of ods which are currently not exposed like mixins, utils, and helpers.

## Related Issue
- superseeds & prepares https://github.com/owncloud/owncloud-design-system/pull/1838

## How Has This Been Tested?
manual installation by using yarn link

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [X] Technical debt

## Checklist:
<!-- Tick the checkboxes when done. -->
- [X] Code changes