### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/atoms/OcResourceName/OcResourceName.vue
+++ b/src/components/atoms/OcResourceName/OcResourceName.vue
@@ -69,7 +69,7 @@ export default {
 
     displayName() {
       if (this.extension) {
-        return this.name.substr(0, this.name.length - this.extension.length - 1)
+        return this.name.slice(0, -this.extension.length - 1)
       }
       return this.name
     },

--- a/src/components/atoms/OcSelect/OcSelect.vue
+++ b/src/components/atoms/OcSelect/OcSelect.vue
@@ -370,7 +370,7 @@ It is important to specify the `option-label` prop on the `oc-select` to make fi
         Your search query hasn't returned any results.
       </template>
       <template #selected-option="{ title, desc }">
-        <strong class="oc-mr-s" v-text="title" /> <small v-text="desc.substr(0, 20) + '...'" />
+        <strong class="oc-mr-s" v-text="title" /> <small v-text="desc.slice(0, 20) + '...'" />
       </template>
     </oc-select>
     <p>

--- a/src/components/molecules/OcAvatar/OcAvatar.vue
+++ b/src/components/molecules/OcAvatar/OcAvatar.vue
@@ -33,7 +33,7 @@ const getInitials = userName => {
     initials = initials.replace(/[a-z]+/g, "")
   }
 
-  initials = initials.substr(0, 3).toUpperCase()
+  initials = initials.slice(0, 3).toUpperCase()
 
   return initials
 }

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -711,7 +711,7 @@ export default {
             const hours = date.getHours()
             const minutes = "0" + date.getMinutes()
             const seconds = "0" + date.getSeconds()
-            return hours + ":" + minutes.substr(-2) + ":" + seconds.substr(-2)
+            return hours + ":" + minutes.slice(-2) + ":" + seconds.slice(-2)
           }
         }]
       },


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Related Issue


## Motivation and Context

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated .


## How Has This Been Tested?

I tested the return of each statement to make sure it's still the same as before


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 

## Open tasks:

