### PR TITLE
Style fixes for menus

### DIFF
--- a/changelog/unreleased/enhancement-hover-in-oc-drop-menues
+++ b/changelog/unreleased/enhancement-hover-in-oc-drop-menues
@@ -1,0 +1,5 @@
+Enhancement: Hover in ocDrop menues
+
+We've added the "action-menu-item-hover" class for <li> elements inside ocDrop, to add the hover effect on buttons and links. 
+
+https://github.com/owncloud/owncloud-design-system/pull/2069

--- a/changelog/unreleased/enhancement-hover-in-oc-drop-menues
+++ b/changelog/unreleased/enhancement-hover-in-oc-drop-menues
@@ -1,5 +1,5 @@
 Enhancement: Hover in ocDrop menues
 
-We've added the "action-menu-item-hover" class for <li> elements inside ocDrop, to add the hover effect on buttons and links. 
+We've added the "oc-menu-item-hover" class for <li> elements inside ocDrop, to add the hover effect on buttons and links. 
 
 https://github.com/owncloud/owncloud-design-system/pull/2069

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -213,6 +213,7 @@ export default {
     button:not([role="switch"]) {
       box-sizing: border-box;
       padding: var(--oc-space-small);
+      color: var(--oc-color-swatch-passive-default);
       &:focus,
       &:hover {
         background-color: var(--oc-color-background-hover);

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -208,7 +208,7 @@ export default {
     // note: needed so that the box shadow from `oc-box-shadow-medium` doesn't get suppressed
     padding: 8px;
   }
-  li.action-menu-item-hover {
+  li.oc-menu-item-hover {
     a,
     button:not([role="switch"]) {
       box-sizing: border-box;

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -207,24 +207,24 @@ export default {
   .tippy-content {
     // note: needed so that the box shadow from `oc-box-shadow-medium` doesn't get suppressed
     padding: 8px;
-    li {
-      a,
-      button:not([role="switch"]) {
-        box-sizing: border-box;
-        padding: 6px;
-        &:focus,
-        &:hover {
-          background-color: var(--oc-color-background-hover);
+  }
+  li.action-menu-item-hover {
+    a,
+    button:not([role="switch"]) {
+      box-sizing: border-box;
+      padding: var(--oc-space-small);
+      &:focus,
+      &:hover {
+        background-color: var(--oc-color-background-hover);
 
-          text-decoration: none !important;
-          border-radius: 5px;
-        }
-        &:hover span {
-          color: var(--oc-color-swatch-brand-hover) !important;
-        }
-        span {
-          text-decoration: none !important;
-        }
+        text-decoration: none !important;
+        border-radius: 5px;
+      }
+      &:hover span {
+        color: var(--oc-color-swatch-brand-hover) !important;
+      }
+      span {
+        text-decoration: none !important;
       }
     }
   }

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -207,6 +207,28 @@ export default {
   .tippy-content {
     // note: needed so that the box shadow from `oc-box-shadow-medium` doesn't get suppressed
     padding: 8px;
+
+    li {
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      a,
+      button:not([role="switch"]) {
+        padding: 6px;
+        &:focus,
+        &:hover {
+          background-color: var(--oc-color-background-hover);
+
+          text-decoration: none !important;
+          color: var(--oc-color-swatch-brand-hover);
+          .oc-icon > svg {
+            fill: var(--oc-color-swatch-brand-hover) !important;
+          }
+        }
+        span {
+          text-decoration: none !important;
+        }
+      }
+    }
   }
 }
 

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -213,13 +213,17 @@ export default {
       padding-right: 0 !important;
       a,
       button:not([role="switch"]) {
+        box-sizing: border-box;
         padding: 6px;
         &:focus,
         &:hover {
           background-color: var(--oc-color-background-hover);
 
           text-decoration: none !important;
-          color: var(--oc-color-swatch-brand-hover);
+          border-radius: 5px;
+        }
+        &:hover span {
+          color: var(--oc-color-swatch-brand-hover) !important;
         }
         span {
           text-decoration: none !important;

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -207,10 +207,7 @@ export default {
   .tippy-content {
     // note: needed so that the box shadow from `oc-box-shadow-medium` doesn't get suppressed
     padding: 8px;
-
     li {
-      padding-left: 0 !important;
-      padding-right: 0 !important;
       a,
       button:not([role="switch"]) {
         box-sizing: border-box;

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -220,9 +220,6 @@ export default {
 
           text-decoration: none !important;
           color: var(--oc-color-swatch-brand-hover);
-          .oc-icon > svg {
-            fill: var(--oc-color-swatch-brand-hover) !important;
-          }
         }
         span {
           text-decoration: none !important;

--- a/src/components/molecules/OcBreadcrumb/OcBreadcrumb.vue
+++ b/src/components/molecules/OcBreadcrumb/OcBreadcrumb.vue
@@ -183,10 +183,6 @@ export default {
     #oc-breadcrumb-contextmenu-trigger > span {
       vertical-align: middle;
       border: 3px solid transparent;
-      &:hover {
-        background-color: var(--oc-color-background-hover);
-        border-radius: 5px;
-      }
     }
 
     #oc-breadcrumb-contextmenu li button {

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -472,7 +472,7 @@ export default {
     transition: background-color $transition-duration-short ease-in-out;
   }
 
-  &-hover tr:hover span:not(.avatarInitials):not(button span) {
+  &-hover tr:hover td:not(:last-child) span:not(.avatarInitials):not(button span) {
     color: var(--oc-color-swatch-brand-hover) !important;
   }
 


### PR DESCRIPTION
## Description
- moving hover effect for tippy-box implemented in web to ods: adding hovers on "New" menus
- unifying spacings for tippy-box menus
- web part: https://github.com/owncloud/web/pull/6762

## Related Issue
Fixes hover menus issues from https://github.com/owncloud/web/issues/6555

## Motivation and Context
More consistency in style of different menus:


## Screenshots (if appropriate):
![menus](https://user-images.githubusercontent.com/7430156/162973959-b086af9d-6782-4492-96af-33f8ee8cc9f0.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

