### PR TITLE
Fix tooltips overflowing on long words

### DIFF
--- a/changelog/unreleased/bugfix-tooltip-break-word
+++ b/changelog/unreleased/bugfix-tooltip-break-word
@@ -1,0 +1,5 @@
+Bugfix: Add word breaking in tooltips
+
+We've added word wrapping to the tippy tooltips so they handle very long paths properly.
+
+https://github.com/owncloud/owncloud-design-system/pull/2137

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -199,6 +199,11 @@ export default {
 </script>
 
 <style lang="scss">
+.tippy-box {
+  .tippy-content {
+    word-wrap: break-word;
+  }
+}
 .tippy-box[data-theme~="none"] {
   background-color: transparent;
   font-size: inherit;

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -199,11 +199,6 @@ export default {
 </script>
 
 <style lang="scss">
-.tippy-box {
-  .tippy-content {
-    word-wrap: break-word;
-  }
-}
 .tippy-box[data-theme~="none"] {
   background-color: transparent;
   font-size: inherit;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -19,3 +19,4 @@
 @import "theme/oc-transitions";
 @import "theme/oc-visibility";
 @import "theme/oc-width";
+@import "theme/tooltip";

--- a/src/styles/theme/tooltip.scss
+++ b/src/styles/theme/tooltip.scss
@@ -1,0 +1,5 @@
+.tippy-box {
+  .tippy-content {
+    word-wrap: break-word;
+  }
+}


### PR DESCRIPTION
This PR fixes long words or paths breaking the tooltips in the sidebar:

![image](https://user-images.githubusercontent.com/6058151/168079139-d00351d6-91de-41fe-8606-5248d31fbc57.png)


By adding a `word-wrap: break-word` to the tippy content.

![image](https://user-images.githubusercontent.com/6058151/168079330-b88bea29-66f9-4f06-a8c6-2115e12b74d3.png)

This along with ellipsizing the paths will remove the scrollbar from the sidebar.