### PR TITLE
Fix text color of buttons and avatars in hovered table rows

### DIFF
--- a/changelog/unreleased/bugfix-text-color-buttons-avatars-in-hovered-rows
+++ b/changelog/unreleased/bugfix-text-color-buttons-avatars-in-hovered-rows
@@ -1,0 +1,6 @@
+Bugfix: Text color of buttons and avatars in hovered table rows
+
+We fixed an issue that made text of buttons and avatars inside hovered rows bad readable for light mode.
+
+https://github.com/owncloud/owncloud-design-system/pull/2139
+https://github.com/owncloud/owncloud-design-system/issues/2138

--- a/src/components/molecules/OcTable/OcTable.vue
+++ b/src/components/molecules/OcTable/OcTable.vue
@@ -472,7 +472,7 @@ export default {
     transition: background-color $transition-duration-short ease-in-out;
   }
 
-  &-hover tr:hover span {
+  &-hover tr:hover span:not(.avatarInitials):not(button span) {
     color: var(--oc-color-swatch-brand-hover) !important;
   }
 


### PR DESCRIPTION
## Description
- Prevent hover span color from applying to buttons and avatars

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #2138

## Motivation and Context
Improve the contrast


## Screenshots (if appropriate):
Before and after
![Untitled_ May 12, 2022 3_37 PM](https://user-images.githubusercontent.com/7430156/168091803-a12bb933-cdf5-4bca-b4e9-b08fa8f843a5.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

## Open tasks:
<!-- In case of incomplete PR, please list the open tasks here -->
- [ ] ...
