### PR TITLE
Align submit-via-enter for OcModal input with submit button

### DIFF
--- a/changelog/unreleased/bugfix-modal-input-enter-submission
+++ b/changelog/unreleased/bugfix-modal-input-enter-submission
@@ -1,0 +1,8 @@
+Bugfix: Fix event handler for submit-via-enter in OcModal input
+
+We fixed a small difference between clicking the confirm button and
+hitting the enter key when using an OcModal with an input field, which 
+lead to unexpected behaviour.
+
+https://github.com/owncloud/owncloud-design-system/pull/2159
+https://github.com/owncloud/web/pull/6961#pullrequestreview-979854434

--- a/src/components/organisms/OcModal/OcModal.vue
+++ b/src/components/organisms/OcModal/OcModal.vue
@@ -31,7 +31,7 @@
             :fix-message-line="true"
             :selection-range="inputSelectionRange"
             @input="inputOnInput"
-            @keydown.enter="confirm"
+            @keydown.enter.prevent="confirm"
           />
           <p v-else key="modal-message" class="oc-modal-body-message" v-text="message" />
           <div class="oc-modal-body-actions oc-flex oc-flex-right">


### PR DESCRIPTION
## Description
This surfaces in https://github.com/owncloud/web/pull/6961 where using the enter key upon password modification would continue in the code but not close the modal (while clicking the confirm button did both). Please link this PR locally with the mentioned `web` PR for testing