### PR TITLE
Add HTML title to the resourceName component

### DIFF
--- a/changelog/unreleased/enhancement-resource-name-html-title
+++ b/changelog/unreleased/enhancement-resource-name-html-title
@@ -1,0 +1,5 @@
+Enhancement: Add HTML title to the resourceName component
+
+We've added the HTML title attribute to the resourceName component in case no tooltip is being displayed.
+
+https://github.com/owncloud/owncloud-design-system/pull/2164

--- a/src/components/atoms/OcResourceName/OcResourceName.spec.js
+++ b/src/components/atoms/OcResourceName/OcResourceName.spec.js
@@ -82,4 +82,32 @@ describe("OcResourceName", () => {
 
     expect(wrapper).toMatchSnapshot()
   })
+
+  it("shows the name as HTML title if the path is not displayed", () => {
+    const wrapper = shallowMount(Name, {
+      propsData: {
+        fullPath: "folder",
+        name: "folder",
+        extension: "",
+        type: "folder",
+        isPathDisplayed: false,
+      },
+    })
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  it("does not show the name as HTML title if the path is being displayed", () => {
+    const wrapper = shallowMount(Name, {
+      propsData: {
+        fullPath: "folder",
+        name: "folder",
+        extension: "",
+        type: "folder",
+        isPathDisplayed: true,
+      },
+    })
+
+    expect(wrapper).toMatchSnapshot()
+  })
 })

--- a/src/components/atoms/OcResourceName/OcResourceName.vue
+++ b/src/components/atoms/OcResourceName/OcResourceName.vue
@@ -6,6 +6,7 @@
     :data-test-resource-path="fullPath"
     :data-test-resource-name="fullName"
     :data-test-resource-type="type"
+    :title="htmlTitle"
   >
     <span v-if="truncateName" class="oc-text-truncate">
       <span class="oc-resource-basename" v-text="displayName" />
@@ -121,6 +122,18 @@ export default {
         return null
       }
       return this.fullPath
+    },
+
+    htmlTitle() {
+      if (this.tooltip) {
+        return
+      }
+
+      if (this.isExtensionDisplayed) {
+        return `${this.displayName}${this.displayExtension}`
+      }
+
+      return this.displayName
     },
   },
 }

--- a/src/components/atoms/OcResourceName/__snapshots__/OcResourceName.spec.js.snap
+++ b/src/components/atoms/OcResourceName/__snapshots__/OcResourceName.spec.js.snap
@@ -1,15 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcResourceName does not truncate a very long name when disabled 1`] = `<span data-test-resource-path="super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-name=".super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-type="file" class="oc-resource-name oc-display-inline-block"><span class="oc-resource-basename oc-text-break">.super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end</span><span class="oc-resource-extension">.txt</span></span>`;
+exports[`OcResourceName does not show the name as HTML title if the path is being displayed 1`] = `
+<span data-test-resource-path="folder" data-test-resource-name="folder" data-test-resource-type="folder" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">folder</span></span>
+<!----></span>
+`;
+
+exports[`OcResourceName does not truncate a very long name when disabled 1`] = `<span data-test-resource-path="super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-name=".super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-type="file" title=".super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" class="oc-resource-name oc-display-inline-block"><span class="oc-resource-basename oc-text-break">.super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end</span><span class="oc-resource-extension">.txt</span></span>`;
 
 exports[`OcResourceName doesn't add extension to hidden folder 1`] = `
-<span data-test-resource-path=".hidden" data-test-resource-name=".hidden" data-test-resource-type="folder" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">.hidden</span></span>
+<span data-test-resource-path=".hidden" data-test-resource-name=".hidden" data-test-resource-type="folder" title=".hidden" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">.hidden</span></span>
 <!----></span>
 `;
 
 exports[`OcResourceName renders folder names with dots completely in the basename 1`] = `
-<span data-test-resource-path="folder.with.dots" data-test-resource-name="folder.with.dots" data-test-resource-type="folder" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">folder.with.dots</span></span>
+<span data-test-resource-path="folder.with.dots" data-test-resource-name="folder.with.dots" data-test-resource-type="folder" title="folder.with.dots" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">folder.with.dots</span></span>
 <!----></span>
 `;
 
-exports[`OcResourceName truncates very long name per default 1`] = `<span data-test-resource-path="super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-name=".super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-type="file" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">.super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end</span></span><span class="oc-resource-extension">.txt</span></span>`;
+exports[`OcResourceName shows the name as HTML title if the path is not displayed 1`] = `
+<span data-test-resource-path="folder" data-test-resource-name="folder" data-test-resource-type="folder" title="folder" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">folder</span></span>
+<!----></span>
+`;
+
+exports[`OcResourceName truncates very long name per default 1`] = `<span data-test-resource-path="super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-name=".super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" data-test-resource-type="file" title=".super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end.txt" class="oc-resource-name"><span class="oc-text-truncate"><span class="oc-resource-basename">.super-long-file-name-which-will-be-truncated-when-exceeding-the-screen-space-while-still-preserving-the-file-extension-at-the-end</span></span><span class="oc-resource-extension">.txt</span></span>`;


### PR DESCRIPTION
## Description
We've added the HTML title attribute to the resourceName component in case no tooltip is being displayed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/6776

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
