### PR TITLE
Implement an indeterminate state for the progress bar

### DIFF
--- a/changelog/unreleased/enhancement-progress-bar-indeterminate-state
+++ b/changelog/unreleased/enhancement-progress-bar-indeterminate-state
@@ -1,0 +1,6 @@
+Enhancement: Progress bar indeterminate state
+
+We've added an indeterminate state to the progress bar.
+
+https://github.com/owncloud/owncloud-design-system/pull/2200
+https://github.com/owncloud/web/issues/7105

--- a/src/components/atoms/OcProgress/OcProgress.vue
+++ b/src/components/atoms/OcProgress/OcProgress.vue
@@ -34,7 +34,11 @@ export default {
      */
     max: {
       type: Number,
-      required: true,
+      required: false,
+      default: undefined,
+      validator: value => {
+        return value >= 0
+      },
     },
     /**
      * The size of the progress bar.
@@ -76,6 +80,9 @@ export default {
       return `oc-progress oc-progress-${this.size} oc-progress-${this.variation}`
     },
     progressValue() {
+      if (!this.max) {
+        return "-"
+      }
       const num = (this.value / this.max) * 100
       return `${num}%`
     },

--- a/src/components/atoms/OcProgress/OcProgress.vue
+++ b/src/components/atoms/OcProgress/OcProgress.vue
@@ -37,7 +37,7 @@ export default {
       required: false,
       default: undefined,
       validator: value => {
-        return value >= 0
+        return value > 0
       },
     },
     /**

--- a/src/components/atoms/OcProgress/OcProgress.vue
+++ b/src/components/atoms/OcProgress/OcProgress.vue
@@ -1,14 +1,17 @@
 <template>
-  <progress
-    :value="value"
-    :max="max"
+  <div
+    :class="classes"
     :aria-valuemax="max"
     :aria-valuenow="value"
     aria-busy="true"
     aria-valuemin="0"
-    :class="$_ocProgress_classes"
-    tabindex="-1"
-  />
+  >
+    <div v-if="!indeterminate" class="oc-progress-current" :style="{ width: progressValue }"></div>
+    <div v-else class="oc-progress-indeterminate">
+      <div class="oc-progress-indeterminate-first"></div>
+      <div class="oc-progress-indeterminate-second"></div>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -57,11 +60,23 @@ export default {
         return value.match(/(primary|passive|success|warning|danger)/)
       },
     },
+    /**
+     * Determines if the progress bar should be displayed in an indeterminate state.
+     */
+    indeterminate: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
   },
 
   computed: {
-    $_ocProgress_classes() {
+    classes() {
       return `oc-progress oc-progress-${this.size} oc-progress-${this.variation}`
+    },
+    progressValue() {
+      const num = (this.value / this.max) * 100
+      return `${num}%`
     },
   },
 }
@@ -72,110 +87,75 @@ $progress-height: 15px !default;
 $progress-height-small: 5px !default;
 
 .oc-progress {
-  // Remove default style
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  // Set background color for progress container in Firefox, IE11 and Edge
   background-color: var(--oc-color-input-border);
-  // Remove default style
-  border: 0;
   display: block;
   height: $progress-height;
   // Add the correct vertical alignment in Chrome, Firefox, and Opera.
   width: 100%;
-
-  &:focus {
-    outline: none;
-  }
-
-  // Remove animated circles for indeterminate state in IE11 and Edge
-  &:indeterminate {
-    color: transparent;
-  }
-
-  &::-webkit-progress-bar {
-    background-color: var(--oc-color-input-border);
-  }
-
-  &::-moz-progress-bar {
-    background-color: var(--oc-color-input-border);
-  }
-
-  // Remove progress bar for indeterminate state in Firefox
-  &:indeterminate::-moz-progress-bar {
-    width: 0;
-  }
-
-  &::-webkit-progress-value {
-    background-color: var(--oc-color-swatch-passive-default);
-    transition: width $transition-duration-short ease;
-  }
-
-  &::-ms-fill {
-    background-color: var(--oc-color-swatch-passive-default);
-    // Remove right border in IE11 and Edge
-    border: 0;
-    transition: width $transition-duration-short ease;
-  }
+  position: relative;
+  overflow-x: hidden;
 
   &-small {
     height: $progress-height-small;
   }
+  &-current {
+    height: 100%;
+    position: absolute;
+    transition: width 0.5s;
+  }
+  &-indeterminate div {
+    height: 100%;
+    position: absolute;
+  }
+  &-indeterminate-first {
+    animation-duration: 2s;
+    animation-name: indeterminate-first;
+    animation-iteration-count: infinite;
+  }
+  &-indeterminate-second {
+    animation-duration: 2s;
+    animation-delay: 0.5s;
+    animation-name: indeterminate-second;
+    animation-iteration-count: infinite;
+  }
 
-  &-primary {
-    &::-webkit-progress-value {
-      background-color: var(--oc-color-swatch-primary-default);
+  @keyframes indeterminate-first {
+    from {
+      left: -10%;
+      width: 10%;
     }
-
-    &::-moz-progress-bar {
-      background-color: var(--oc-color-swatch-primary-default);
-    }
-
-    &::-ms-fill {
-      background-color: var(--oc-color-swatch-primary-default);
+    to {
+      left: 120%;
+      width: 100%;
     }
   }
 
-  &-success {
-    &::-webkit-progress-value {
-      background-color: var(--oc-color-swatch-success-default);
+  @keyframes indeterminate-second {
+    from {
+      left: -100%;
+      width: 80%;
     }
-
-    &::-moz-progress-bar {
-      background-color: var(--oc-color-swatch-success-default);
-    }
-
-    &::-ms-fill {
-      background-color: var(--oc-color-swatch-success-default);
+    to {
+      left: 110%;
+      width: 10%;
     }
   }
 
-  &-warning {
-    &::-webkit-progress-value {
-      background-color: var(--oc-color-swatch-warning-default);
-    }
-
-    &::-moz-progress-bar {
-      background-color: var(--oc-color-swatch-warning-default);
-    }
-
-    &::-ms-fill {
-      background-color: var(--oc-color-swatch-warning-default);
-    }
+  &-primary &-current,
+  &-primary &-indeterminate div {
+    background-color: var(--oc-color-swatch-primary-default);
   }
-
-  &-danger {
-    &::-webkit-progress-value {
-      background-color: var(--oc-color-swatch-danger-default);
-    }
-
-    &::-moz-progress-bar {
-      background-color: var(--oc-color-swatch-danger-default);
-    }
-
-    &::-ms-fill {
-      background-color: var(--oc-color-swatch-danger-default);
-    }
+  &-success &-current,
+  &-success &-indeterminate div {
+    background-color: var(--oc-color-swatch-success-default);
+  }
+  &-warning &-current,
+  &-warning &-indeterminate div {
+    background-color: var(--oc-color-swatch-warning-default);
+  }
+  &-danger &-current,
+  &-danger &-indeterminate div {
+    background-color: var(--oc-color-swatch-danger-default);
   }
 }
 </style>
@@ -186,7 +166,9 @@ Show progress to the users.
 ```js
 <div>
   <oc-progress :value="4" :max="10" class="oc-mb-s" />
-  <oc-progress :value="8" :max="10" size="small" variation="warning" />
+  <oc-progress :value="8" :max="10" size="small" variation="warning" class="oc-mb-s"  />
+  <oc-progress :max="10" :indeterminate="true" size="small" />
+
 </div>
 ```
 </docs>

--- a/src/components/atoms/OcProgress/OcProgress.vue
+++ b/src/components/atoms/OcProgress/OcProgress.vue
@@ -5,6 +5,7 @@
     :aria-valuenow="value"
     aria-busy="true"
     aria-valuemin="0"
+    role="progressbar"
   >
     <div v-if="!indeterminate" class="oc-progress-current" :style="{ width: progressValue }"></div>
     <div v-else class="oc-progress-indeterminate">

--- a/src/components/atoms/OcProgress/__snapshots__/OcProgress.spec.js.snap
+++ b/src/components/atoms/OcProgress/__snapshots__/OcProgress.spec.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`OcProgress sets correct classes 1`] = `<progress max="10" aria-valuemax="10" aria-valuenow="3" aria-busy="true" aria-valuemin="0" tabindex="-1" class="oc-progress oc-progress-small oc-progress-warning" value="3"></progress>`;
+exports[`OcProgress sets correct classes 1`] = `
+<div aria-valuemax="10" aria-valuenow="3" aria-busy="true" aria-valuemin="0" class="oc-progress oc-progress-small oc-progress-warning">
+  <div class="oc-progress-current" style="width: 30%;"></div>
+</div>
+`;

--- a/src/components/atoms/OcProgress/__snapshots__/OcProgress.spec.js.snap
+++ b/src/components/atoms/OcProgress/__snapshots__/OcProgress.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OcProgress sets correct classes 1`] = `
-<div aria-valuemax="10" aria-valuenow="3" aria-busy="true" aria-valuemin="0" class="oc-progress oc-progress-small oc-progress-warning">
+<div aria-valuemax="10" aria-valuenow="3" aria-busy="true" aria-valuemin="0" role="progressbar" class="oc-progress oc-progress-small oc-progress-warning">
   <div class="oc-progress-current" style="width: 30%;"></div>
 </div>
 `;

--- a/src/vuetify.js
+++ b/src/vuetify.js
@@ -1,8 +1,0 @@
-import Vue from "vue"
-import Vuetify from "vuetify"
-
-Vue.use(Vuetify, { rtl: false })
-
-export default new Vuetify({
-  rtl: false,
-})

--- a/src/vuetify.js
+++ b/src/vuetify.js
@@ -1,0 +1,8 @@
+import Vue from "vue"
+import Vuetify from "vuetify"
+
+Vue.use(Vuetify, { rtl: false })
+
+export default new Vuetify({
+  rtl: false,
+})


### PR DESCRIPTION
## Description
We've added an indeterminate state to the progress bar.

I've decided to build the indeterminate state myself (okay, with quite some help from StackOverflow :D) because the integration of Vuetify is a bit more complex than I anticipated. We can still do this later if neccessary.

## Related Issue
Needed for https://github.com/owncloud/web/issues/7105

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/50302941/173364614-e07fa842-c8fb-4e7d-b1ed-8611c55db48e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
