### PR TITLE
Nested drop functionality

### DIFF
--- a/changelog/13.1.0_2022-06-07/enhancement-add-nested-drop
+++ b/changelog/13.1.0_2022-06-07/enhancement-add-nested-drop
@@ -1,0 +1,6 @@
+Enhancement: Add nestedd drop functionality
+
+We've added the property "isNested" to ocDrop that prevents the parent drop from hiding by not firing hideAll() in the child drop
+
+https://github.com/owncloud/owncloud-design-system/issues/2238
+https://github.com/owncloud/owncloud-design-system/pull/2239

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -83,6 +83,13 @@ export default {
       required: false,
     },
     /**
+     * Defines if the drop should be nested drop in another drop.
+     */
+    isNested: {
+      type: Boolean,
+      required: false,
+    },
+    /**
      * Element selector used as a target of the drop
      */
     target: {
@@ -143,7 +150,7 @@ export default {
     if (!to || !content) {
       return
     }
-
+    let isNested = this.isNested
     const config = {
       trigger: this.triggerMapping,
       placement: this.position,
@@ -155,9 +162,11 @@ export default {
       aria: {
         content: "describedby",
       },
-      onShow(instance) {
-        hideAll({ exclude: instance })
-      },
+      ...(!isNested && {
+        onShow(instance) {
+          hideAll({ exclude: instance })
+        },
+      }),
       popperOptions: this.popperOptions,
       content,
     }
@@ -273,7 +282,7 @@ export default {
       </ul>
     </oc-drop>
 
-    <oc-button id="my_advanced">Advanced</oc-button>
+    <oc-button id="my_advanced" class="oc-mr-s">Advanced</oc-button>
     <oc-drop dropId="oc-drop" toggle="#my_advanced" mode="click" closeOnClick>
       <div slot="special" class="oc-card">
         <div class="oc-card-header">
@@ -287,6 +296,52 @@ export default {
           </p>
         </div>
       </div>
+    </oc-drop>
+
+    <oc-button id="my_submenu_parent"> With submenu</oc-button>
+    <oc-drop
+      id="drop"
+      ref="submenu_parent"
+      drop-id="oc-drop"
+      toggle="#my_submenu_parent"
+      mode="click"
+      style="max-width: 200px"
+    >
+      <oc-list class="user-menu-list">
+        <li>
+          <oc-button appearance="raw"> Menu item 1</oc-button>
+        </li>
+        <li>
+          <oc-button id="menu_with_submenu" appearance="raw">
+            Menu item 2<oc-icon
+              name="arrow-drop-right"
+              fill-type="line"
+              class="oc-p-xs"
+            />
+          </oc-button>
+          <oc-drop
+            id="submenu"
+            toggle="#menu_with_submenu"
+            mode="hover"
+            position="right-start"
+            isNested
+            closeOnClick
+            style="max-width: 200px"
+          >
+            <oc-list class="user-menu-list">
+              <li>
+                <oc-button appearance="raw"> Submenu item 1 </oc-button>
+              </li>
+              <li>
+                <oc-button appearance="raw"> Submenu item 2 </oc-button>
+              </li>
+            </oc-list>
+          </oc-drop>
+        </li>
+        <li>
+          <oc-button appearance="raw"> Menu item 3</oc-button>
+        </li>
+      </oc-list>
     </oc-drop>
   </div>
 </template>

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -162,7 +162,7 @@ export default {
       aria: {
         content: "describedby",
       },
-      ...(!isNested && {
+      ...(!this.isNested && {
         onShow(instance) {
           hideAll({ exclude: instance })
         },

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -150,7 +150,6 @@ export default {
     if (!to || !content) {
       return
     }
-    let isNested = this.isNested
     const config = {
       trigger: this.triggerMapping,
       placement: this.position,


### PR DESCRIPTION
## Description
Adds "isNested" property to ocDrop that prevents the parent drop from hiding (not fires hideAll() in onShow() of child drop)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/owncloud-design-system/issues/2238

## Motivation and Context
Useful to create submenus


## Screenshots (if appropriate):
![ocDrop](https://user-images.githubusercontent.com/7430156/177501937-63ef0ad8-24a0-4aac-9336-25a5c2ac4fed.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [] Documentation added/updated


