### PR TITLE
fix: group avatars by long group names in sidebar

### DIFF
--- a/changelog/unreleased/bugfix-oc-avatar-item-width-shrinking
+++ b/changelog/unreleased/bugfix-oc-avatar-item-width-shrinking
@@ -1,0 +1,6 @@
+Bugfix: Remove width shrinking of the ocAvatarItem
+
+We fixed an issue that the width of ocAvatarItem is shrinking in the sidebar of web by longer group names
+
+https://github.com/owncloud/owncloud-design-system/issues/2241
+https://github.com/owncloud/owncloud-design-system/pull/2242

--- a/src/components/atoms/OcAvatarItem/OcAvatarItem.vue
+++ b/src/components/atoms/OcAvatarItem/OcAvatarItem.vue
@@ -1,15 +1,21 @@
 <template>
-  <span
-    class="oc-avatar-item"
-    :style="{ backgroundColor: backgroundColor, '--icon-color': iconColor, '--width': avatarWidth }"
-    :aria-label="accessibleLabel === '' ? null : accessibleLabel"
-    :aria-hidden="accessibleLabel === '' ? 'true' : null"
-    :focusable="accessibleLabel === '' ? 'false' : null"
-    :role="accessibleLabel === '' ? null : 'img'"
-    :data-test-item-name="name"
-  >
-    <oc-icon v-if="hasIcon" :name="icon" :size="iconSize" :fill-type="iconFillType" />
-  </span>
+  <div :aria-hidden="true">
+    <span
+      class="oc-avatar-item"
+      :style="{
+        backgroundColor: backgroundColor,
+        '--icon-color': iconColor,
+        '--width': avatarWidth,
+      }"
+      :aria-label="accessibleLabel === '' ? null : accessibleLabel"
+      :aria-hidden="accessibleLabel === '' ? 'true' : null"
+      :focusable="accessibleLabel === '' ? 'false' : null"
+      :role="accessibleLabel === '' ? null : 'img'"
+      :data-test-item-name="name"
+    >
+      <oc-icon v-if="hasIcon" :name="icon" :size="iconSize" :fill-type="iconFillType" />
+    </span>
+  </div>
 </template>
 
 <script>

--- a/src/components/atoms/OcAvatarItem/OcAvatarItem.vue
+++ b/src/components/atoms/OcAvatarItem/OcAvatarItem.vue
@@ -1,5 +1,11 @@
 <template>
-  <div :aria-hidden="true">
+  <div
+    :data-test-item-name="name"
+    :aria-label="accessibleLabel === '' ? null : accessibleLabel"
+    :aria-hidden="accessibleLabel === '' ? 'true' : null"
+    :focusable="accessibleLabel === '' ? 'false' : null"
+    :role="accessibleLabel === '' ? null : 'img'"
+  >
     <span
       class="oc-avatar-item"
       :style="{
@@ -7,11 +13,6 @@
         '--icon-color': iconColor,
         '--width': avatarWidth,
       }"
-      :aria-label="accessibleLabel === '' ? null : accessibleLabel"
-      :aria-hidden="accessibleLabel === '' ? 'true' : null"
-      :focusable="accessibleLabel === '' ? 'false' : null"
-      :role="accessibleLabel === '' ? null : 'img'"
-      :data-test-item-name="name"
     >
       <oc-icon v-if="hasIcon" :name="icon" :size="iconSize" :fill-type="iconFillType" />
     </span>


### PR DESCRIPTION
## Description
Fixes avatar width shrinking by group avatars

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/owncloud-design-system/issues/2241


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated

