### PR TITLE
Omit special chars from avatar initials

### DIFF
--- a/changelog/unreleased/bugfix-avatar-initials-special-chars
+++ b/changelog/unreleased/bugfix-avatar-initials-special-chars
@@ -1,0 +1,6 @@
+Bugfix: Omit special characters in user avatar initials
+
+We now make sure that user avatars without a picture (i.e. rendering user initials) only show unicode letters and numbers.
+
+https://github.com/owncloud/owncloud-design-system/issues/2070
+https://github.com/owncloud/owncloud-design-system/pull/2267

--- a/src/components/molecules/OcAvatar/OcAvatar.spec.js
+++ b/src/components/molecules/OcAvatar/OcAvatar.spec.js
@@ -1,5 +1,50 @@
 import { mount } from "@vue/test-utils"
-import OcAvatar from "./OcAvatar.vue"
+import OcAvatar, { extractInitials } from "./OcAvatar.vue"
+
+describe("extractInitials", () => {
+  describe("should allow alphanumeric characters", () => {
+    it.each([
+      ["test", "T"],
+      ["Test", "T"],
+      ["1Test", "1"],
+      ["test user", "TU"],
+      ["test User", "TU"],
+      ["Test User", "TU"],
+      ["1234 5678", "15"],
+      ["test-user", "TU"],
+      ["test -user", "TU"],
+      ["test - user", "TU"],
+      ["test user one", "TUO"],
+      ["test-user-one", "TUO"],
+      ["test user one primary", "TUO"],
+      ["testUser One Primary", "TOP"],
+    ])("user name '%s'", (input, expected) => {
+      expect(extractInitials(input)).toBe(expected)
+    })
+  })
+
+  describe("should omit special chars from user names", () => {
+    it.each([
+      [".", ""],
+      ["._-()[]{}", ""],
+      ["test User (with@email.com)", "TUW"],
+    ])("user name '%s'", (input, expected) => {
+      expect(extractInitials(input)).toBe(expected)
+    })
+  })
+
+  describe("should allow letters from non-latin alphabets", () => {
+    it.each([
+      ["१२३ ४५६", "१४"],
+      ["अंशु वर्मा", "अव"],
+      ["किरण पराजुली", "कप"],
+      ["Kiran पराजुली", "Kप"],
+      ["किरण Parajuli", "कP"],
+    ])("user name '%s'", (input, expected) => {
+      expect(extractInitials(input)).toBe(expected)
+    })
+  })
+})
 
 describe("OcAvatar", () => {
   const selectors = {
@@ -33,36 +78,13 @@ describe("OcAvatar", () => {
       })
     })
     describe("when username is set", () => {
-      it.each`
-        username                   | expected_initial
-        ${"."}                     | ${"."}
-        ${"१२३ ४५६"}               | ${"१४"}
-        ${"अंशु वर्मा"}            | ${"अव"}
-        ${"किरण पराजुली"}          | ${"कप"}
-        ${"Kiran पराजुली"}         | ${"Kप"}
-        ${"किरण Parajuli"}         | ${"कP"}
-        ${"test"}                  | ${"T"}
-        ${"Test"}                  | ${"T"}
-        ${"1Test"}                 | ${"1"}
-        ${"test user"}             | ${"TU"}
-        ${"test User"}             | ${"TU"}
-        ${"Test User"}             | ${"TU"}
-        ${"1234 5678"}             | ${"15"}
-        ${"test-user"}             | ${"TU"}
-        ${"test -user"}            | ${"TU"}
-        ${"test - user"}           | ${"TU"}
-        ${"test user one"}         | ${"TUO"}
-        ${"test-user-one"}         | ${"TUO"}
-        ${"test user one primary"} | ${"TUO"}
-        ${"test User One Primary"} | ${"UOP"}
-        ${"testUser One Primary"}  | ${"TOP"}
-      `("should render user initials for username $username", ({ username, expected_initial }) => {
+      it("should render user initials for username 'test user'", () => {
         const wrapper = getWrapperWithProps({
-          userName: username,
+          userName: "test user",
         })
         const userInitialElement = wrapper.find(selectors.initials)
         expect(userInitialElement.exists()).toBeTruthy()
-        expect(userInitialElement.text()).toBe(expected_initial)
+        expect(userInitialElement.text()).toBe("TU")
       })
     })
     describe("when width is set", () => {

--- a/src/components/molecules/OcAvatar/OcAvatar.vue
+++ b/src/components/molecules/OcAvatar/OcAvatar.vue
@@ -17,27 +17,20 @@
 <script>
 import OcImg from "../../atoms/OcImage/OcImage.vue"
 
+export const extractInitials = userName => {
+  return userName
+    .split(/[ -]/)
+    .map(part => part.replace(/[^\p{L}\p{Nd}]/giu, ""))
+    .filter(Boolean)
+    .map(part => part.charAt(0))
+    .slice(0, 3)
+    .join("")
+    .toUpperCase()
+}
+
 /**
  * Avatar is a thumbnail representing user or group
  */
-
-const getInitials = userName => {
-  let parts = userName.split(/[ -]/)
-  let initials = ""
-
-  for (var i = 0; i < parts.length; i++) {
-    initials += parts[i].charAt(0)
-  }
-
-  if (initials.length > 3 && initials.search(/[A-Z]/) !== -1) {
-    initials = initials.replace(/[a-z]+/g, "")
-  }
-
-  initials = initials.slice(0, 3).toUpperCase()
-
-  return initials
-}
-
 export default {
   name: "OcAvatar",
   status: "ready",
@@ -131,8 +124,7 @@ export default {
 
     userInitial() {
       if (!this.isImage) {
-        const initials = getInitials(this.userName)
-        return initials
+        return extractInitials(this.userName)
       }
       return ""
     },


### PR DESCRIPTION
## Description
Omit characters from user avatar initials which don't match the unicode categories "letter" or "number".

Used unicode property escapes for this, further reading: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/owncloud-design-system/issues/2070

## How Has This Been Tested?
Added unit tests for the function that extracts the initials. Reduced the user initials unit tests to one case, because relevant table test cases moved to the function mentioned before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
