### PR TITLE
Add offset property to the drop component

### DIFF
--- a/changelog/unreleased/enhancement-drop-offset
+++ b/changelog/unreleased/enhancement-drop-offset
@@ -1,0 +1,6 @@
+Enhancement: Add offset property to the drop component
+
+We've added an offset property to the drop component to define a custom offset. Also, the max width of drop menus was increased to 400px.
+
+https://github.com/owncloud/web/issues/7335
+https://github.com/owncloud/owncloud-design-system/pull/2276

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -110,6 +110,14 @@ export default {
         return value.match(/(xsmall|small|medium|large|xlarge|xxlarge|xxxlarge|remove)/)
       },
     },
+    /**
+     * Determines the offset of the drop element. The value can work on both axes by using a string in the form "x, y", such as "50, 20".
+     */
+    offset: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   data() {
     return { tippy: null }
@@ -158,6 +166,8 @@ export default {
       interactive: true,
       plugins: [hideOnEsc],
       theme: "none",
+      maxWidth: 400,
+      offset: this.offset,
       aria: {
         content: "describedby",
       },

--- a/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
+++ b/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
@@ -23,7 +23,7 @@ exports[`OcDrop tippy renders tippy 1`] = `
       data-state="visible"
       data-theme="none"
       role="tooltip"
-      style="max-width: 350px; transition-duration: 300ms;"
+      style="max-width: 400px; transition-duration: 300ms;"
       tabindex="-1"
     >
       <div
@@ -69,7 +69,7 @@ exports[`OcDrop tippy renders tippy 2`] = `
       data-state="hidden"
       data-theme="none"
       role="tooltip"
-      style="max-width: 350px; transition-duration: 250ms;"
+      style="max-width: 400px; transition-duration: 250ms;"
       tabindex="-1"
     >
       <div
@@ -116,7 +116,7 @@ exports[`OcDrop tippy renders tippy 3`] = `
       data-state="visible"
       data-theme="none"
       role="tooltip"
-      style="max-width: 350px; transition-duration: 300ms;"
+      style="max-width: 400px; transition-duration: 300ms;"
       tabindex="-1"
     >
       <div


### PR DESCRIPTION
## Description
We've added an offset property to the drop component to define a custom offset. Also, the max width of drop menus was increased to 400px.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/web/issues/7335

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
