### PR TITLE
Align breadcrumb context menu with regular context menu

### DIFF
--- a/changelog/unreleased/enhancement-breadcrumb-context-menu-alignment
+++ b/changelog/unreleased/enhancement-breadcrumb-context-menu-alignment
@@ -1,0 +1,6 @@
+Enhancement: Align breadcrumb context menu with regular context menu
+
+We've aligned the breadcrumb context menu visually to match with the regular context menu in the files table.
+
+https://github.com/owncloud/owncloud-design-system/pull/2296
+https://github.com/owncloud/web/issues/7493

--- a/src/components/molecules/OcBreadcrumb/OcBreadcrumb.vue
+++ b/src/components/molecules/OcBreadcrumb/OcBreadcrumb.vue
@@ -193,9 +193,6 @@ export default {
       display: inline;
     }
 
-    > li a,
-    > li button,
-    > li span,
     > :nth-child(n + 2)::before {
       color: var(--oc-color-text-default);
       display: inline-block;
@@ -216,10 +213,14 @@ export default {
 
   /* stylelint-disable */
   &-list-item {
-    a,
-    button,
-    span {
+    a:first-of-type,
+    button:first-of-type,
+    span:first-of-type {
       font-size: var(--oc-font-size-medium);
+      color: var(--oc-color-text-default);
+      display: inline-block;
+      vertical-align: middle;
+      line-height: normal;
     }
   }
 


### PR DESCRIPTION
## Description
We've aligned the breadcrumb context menu visually to match with the regular context menu in the files table.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7493

## Screenshots (if appropriate):

Old:

![image](https://user-images.githubusercontent.com/50302941/185898816-8e901abb-0d97-48e8-b8c1-f1a6ed2be615.png)

New:

![image](https://user-images.githubusercontent.com/50302941/185898474-363c23fb-3ba8-4b18-be55-45948fb03bb5.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

