### PR TITLE
use single-storey letter a

### DIFF
--- a/changelog/unreleased/enhancement-use-inter
+++ b/changelog/unreleased/enhancement-use-inter
@@ -3,3 +3,4 @@ Enhancement: Use Inter font
 We've switched the default font from Roboto to Inter.
 
 https://github.com/owncloud/owncloud-design-system/pull/2270
+https://github.com/owncloud/owncloud-design-system/pull/2299

--- a/src/styles/theme/oc-text.scss
+++ b/src/styles/theme/oc-text.scss
@@ -14,8 +14,8 @@ html * {
 }
 
 html {
-  font-size: var(--oc-font-size-default);
   font-feature-settings: "cv11";
+  font-size: var(--oc-font-size-default);
 }
 
 a {

--- a/src/styles/theme/oc-text.scss
+++ b/src/styles/theme/oc-text.scss
@@ -15,6 +15,7 @@ html * {
 
 html {
   font-size: var(--oc-font-size-default);
+  font-feature-settings: "cv11";
 }
 
 a {


### PR DESCRIPTION
use single storey letter "a"

what does it do?  
go to https://rsms.me/inter/lab/?feat-cv11=1 and tick "cv 11 (Single-storey a)" and watch how the small letter "a" changes.

What does it improve?  
The rendering of a single storey letter a aligns with our other rounded letters and digits.

## Before

![Screenshot 000316@2x](https://user-images.githubusercontent.com/26610733/186201621-5bc4b9ca-0ece-4e9e-b7db-413282922d97.png)

## After (single storey letter "a")

![Screenshot 000315@2x](https://user-images.githubusercontent.com/26610733/186201296-f5612f4d-8fc6-4c2a-a7aa-ab8b9a9bd3c4.png)