### PR TITLE
fix: adjust border radius of oc-card vs oc-login-card

### DIFF
--- a/changelog/unreleased/enhancement-oc-card-style
+++ b/changelog/unreleased/enhancement-oc-card-style
@@ -4,3 +4,4 @@ We've enhanced the oc-card style classes, to fit better in the corporate design
 
 https://github.com/owncloud/owncloud-design-system/pull/2306
 https://github.com/owncloud/web/issues/7537
+https://github.com/owncloud/owncloud-design-system/pull/2321

--- a/src/components/atoms/OcDrop/OcDrop.vue
+++ b/src/components/atoms/OcDrop/OcDrop.vue
@@ -7,7 +7,7 @@
   >
     <div
       v-if="$slots.default"
-      :class="['oc-card oc-card-body oc-rounded oc-background-secondary', paddingClass]"
+      :class="['oc-card oc-card-body oc-background-secondary', paddingClass]"
     >
       <slot />
     </div>

--- a/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
+++ b/src/components/atoms/OcDrop/__snapshots__/OcDrop.spec.js.snap
@@ -36,7 +36,7 @@ exports[`OcDrop tippy renders tippy 1`] = `
           id="oc-drop-15"
         >
           <div
-            class="oc-card oc-card-body oc-rounded oc-background-secondary oc-p-m"
+            class="oc-card oc-card-body oc-background-secondary oc-p-m"
           >
             show
           </div>
@@ -82,7 +82,7 @@ exports[`OcDrop tippy renders tippy 2`] = `
           id="oc-drop-15"
         >
           <div
-            class="oc-card oc-card-body oc-rounded oc-background-secondary oc-p-m"
+            class="oc-card oc-card-body oc-background-secondary oc-p-m"
           >
             show
           </div>
@@ -129,7 +129,7 @@ exports[`OcDrop tippy renders tippy 3`] = `
           id="oc-drop-15"
         >
           <div
-            class="oc-card oc-card-body oc-rounded oc-background-secondary oc-p-m"
+            class="oc-card oc-card-body oc-background-secondary oc-p-m"
           >
             show
           </div>

--- a/src/styles/theme/login.scss
+++ b/src/styles/theme/login.scss
@@ -21,6 +21,7 @@
   &-card {
     @extend .oc-card;
     @extend .oc-text-center;
+    border-radius: 15px;
 
     &-title {
       @extend .oc-card-title;

--- a/src/styles/theme/login.scss
+++ b/src/styles/theme/login.scss
@@ -21,6 +21,7 @@
   &-card {
     @extend .oc-card;
     @extend .oc-text-center;
+
     border-radius: 15px;
 
     &-title {

--- a/src/styles/theme/oc-card.scss
+++ b/src/styles/theme/oc-card.scss
@@ -4,8 +4,8 @@
 // and shifting towards using our margin/padding helper classes
 
 .oc-card {
+  @extend .oc-rounded;
   background-color: var(--oc-color-background-highlight);
-  border-radius: 15px;
   box-sizing: border-box;
   color: var(--oc-color-text-default);
   position: relative;

--- a/src/styles/theme/oc-card.scss
+++ b/src/styles/theme/oc-card.scss
@@ -5,6 +5,7 @@
 
 .oc-card {
   @extend .oc-rounded;
+
   background-color: var(--oc-color-background-highlight);
   box-sizing: border-box;
   color: var(--oc-color-text-default);


### PR DESCRIPTION
## Description
The border radius of the `oc-card` class was a little bit too heavy for e.g. drop menus where it's also used. We lowered the border-radius of `oc-card` to 5px and set the border-radius only for `oc-login-card` to 15px.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation added/updated
