### PR TITLE
Change button text alignment to left

### DIFF
--- a/changelog/unreleased/enhancement-button-text-align-left
+++ b/changelog/unreleased/enhancement-button-text-align-left
@@ -1,0 +1,6 @@
+Enhancement: Button text align left
+
+We've changed the text alignment of buttons to left.
+
+https://github.com/owncloud/web/issues/7619
+https://github.com/owncloud/owncloud-design-system/pull/2323

--- a/src/components/atoms/OcButton/OcButton.vue
+++ b/src/components/atoms/OcButton/OcButton.vue
@@ -264,7 +264,7 @@ export default {
   display: inline-flex;
   font-weight: 400;
   padding: 0.4rem 0.7rem;
-  text-align: center;
+  text-align: left;
   text-decoration: none;
 
   &-justify-content {


### PR DESCRIPTION
## Description
We've changed the text alignment of buttons to left. We could make it configurable in the future, but for now I don't see a situation where we want to have the text centered.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/web/issues/7619

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
