### PR TITLE
Add cancel-button and -handler to search component

### DIFF
--- a/changelog/unreleased/enhancement-search-cancel
+++ b/changelog/unreleased/enhancement-search-cancel
@@ -1,0 +1,6 @@
+Enhancement: "Chancel"-button and -handler in OcSearchBar
+
+We've added to possibility to have a "cancel"-button and -handler in the `OcSearchBar` component.
+
+https://github.com/owncloud/web/issues/7617
+https://github.com/owncloud/owncloud-design-system/pull/2328

--- a/src/components/atoms/OcSearchBar/OcSearchBar.vue
+++ b/src/components/atoms/OcSearchBar/OcSearchBar.vue
@@ -5,33 +5,44 @@
     class="oc-search"
     :class="{ 'oc-search-small': small }"
   >
-    <div class="oc-width-expand oc-position-relative">
-      <span v-if="icon" class="oc-search-icon" @click="focusSearchInput">
-        <oc-icon v-show="!loading" :name="icon" fill-type="line" />
-        <oc-spinner
-          v-show="loading"
-          :size="spinnerSize"
-          :aria-label="loadingAccessibleLabelValue"
+    <div class="oc-width-expand">
+      <div class="oc-width-1-1 oc-position-relative">
+        <span v-if="icon" class="oc-search-icon" @click="focusSearchInput">
+          <oc-icon v-show="!loading" :name="icon" fill-type="line" />
+          <oc-spinner
+            v-show="loading"
+            :size="spinnerSize"
+            :aria-label="loadingAccessibleLabelValue"
+          />
+        </span>
+        <input
+          ref="searchInput"
+          :class="inputClass"
+          :aria-label="label"
+          :value="searchQuery"
+          :disabled="loading"
+          :placeholder="placeholder"
+          @input="onType($event.target.value)"
+          @keydown.enter="onSearch"
         />
-      </span>
-      <input
-        ref="searchInput"
-        :class="inputClass"
-        :aria-label="label"
-        :value="searchQuery"
-        :disabled="loading"
-        :placeholder="placeholder"
-        @input="onType($event.target.value)"
-        @keydown.enter="onSearch"
-      />
+        <oc-button
+          v-if="query.length > 0"
+          :aria-label="$gettext('Clear search query')"
+          class="oc-search-clear oc-position-small oc-position-center-right oc-mt-rm"
+          appearance="raw"
+          @click="onClear"
+        >
+          <oc-icon name="close" size="small" variation="passive" />
+        </oc-button>
+      </div>
       <oc-button
-        v-if="query.length > 0"
-        :aria-label="$gettext('Clear search query')"
-        class="oc-search-clear oc-position-small oc-position-center-right oc-mt-rm"
+        v-if="showCancelButton"
+        variation="inverse"
+        class="oc-ml-m"
         appearance="raw"
-        @click="onClear"
+        @click="onCancel"
       >
-        <oc-icon name="close" size="small" variation="passive" />
+        <span v-text="$gettext('Cancel')" />
       </oc-button>
     </div>
     <div class="oc-search-button-wrapper" :class="{ 'oc-invisible-sr': buttonHidden }">
@@ -175,6 +186,22 @@ export default {
       required: false,
       default: "",
     },
+    /**
+     * Show a "cancel" button next to the search bar.
+     */
+    showCancelButton: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    /**
+     * Handler function for when the cancel button is clicked.
+     */
+    cancelHandler: {
+      type: Function,
+      required: false,
+      default: () => {},
+    },
   },
   data: () => ({
     query: "",
@@ -237,6 +264,12 @@ export default {
        */
       this.$emit("clear")
     },
+    onCancel() {
+      this.query = ""
+      this.onType("")
+      this.onSearch()
+      this.cancelHandler()
+    },
   },
 }
 </script>
@@ -246,6 +279,13 @@ export default {
   @extend .oc-flex-middle;
 
   min-width: $form-width-medium;
+
+  @media (max-width: 639px) {
+    .oc-width-expand {
+      display: flex;
+      width: 100%;
+    }
+  }
 
   &-button {
     border-bottom-left-radius: 0;

--- a/src/components/atoms/OcSearchBar/OcSearchBar.vue
+++ b/src/components/atoms/OcSearchBar/OcSearchBar.vue
@@ -5,44 +5,33 @@
     class="oc-search"
     :class="{ 'oc-search-small': small }"
   >
-    <div class="oc-width-expand">
-      <div class="oc-width-1-1 oc-position-relative">
-        <span v-if="icon" class="oc-search-icon" @click="focusSearchInput">
-          <oc-icon v-show="!loading" :name="icon" fill-type="line" />
-          <oc-spinner
-            v-show="loading"
-            :size="spinnerSize"
-            :aria-label="loadingAccessibleLabelValue"
-          />
-        </span>
-        <input
-          ref="searchInput"
-          :class="inputClass"
-          :aria-label="label"
-          :value="searchQuery"
-          :disabled="loading"
-          :placeholder="placeholder"
-          @input="onType($event.target.value)"
-          @keydown.enter="onSearch"
+    <div class="oc-width-expand oc-position-relative">
+      <span v-if="icon" class="oc-search-icon" @click="focusSearchInput">
+        <oc-icon v-show="!loading" :name="icon" fill-type="line" />
+        <oc-spinner
+          v-show="loading"
+          :size="spinnerSize"
+          :aria-label="loadingAccessibleLabelValue"
         />
-        <oc-button
-          v-if="query.length > 0"
-          :aria-label="$gettext('Clear search query')"
-          class="oc-search-clear oc-position-small oc-position-center-right oc-mt-rm"
-          appearance="raw"
-          @click="onClear"
-        >
-          <oc-icon name="close" size="small" variation="passive" />
-        </oc-button>
-      </div>
+      </span>
+      <input
+        ref="searchInput"
+        :class="inputClass"
+        :aria-label="label"
+        :value="searchQuery"
+        :disabled="loading"
+        :placeholder="placeholder"
+        @input="onType($event.target.value)"
+        @keydown.enter="onSearch"
+      />
       <oc-button
-        v-if="showCancelButton"
-        variation="inverse"
-        class="oc-ml-m"
+        v-if="query.length"
+        :aria-label="$gettext('Clear search query')"
+        class="oc-search-clear oc-position-small oc-position-center-right oc-mt-rm"
         appearance="raw"
-        @click="onCancel"
+        @click="onClear"
       >
-        <span v-text="$gettext('Cancel')" />
+        <oc-icon name="close" size="small" variation="passive" />
       </oc-button>
     </div>
     <div class="oc-search-button-wrapper" :class="{ 'oc-invisible-sr': buttonHidden }">
@@ -57,6 +46,15 @@
         {{ buttonLabel }}
       </oc-button>
     </div>
+    <oc-button
+      v-if="showCancelButton"
+      :variation="cancelButtonVariation"
+      class="oc-ml-m"
+      appearance="raw"
+      @click="onCancel"
+    >
+      <span v-text="$gettext('Cancel')" />
+    </oc-button>
   </oc-grid>
 </template>
 
@@ -193,6 +191,17 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+    /**
+     * Variation of the cancel button
+     */
+    cancelButtonVariation: {
+      type: String,
+      required: false,
+      default: "primary",
+      validator: value => {
+        return value.match(/(passive|primary|danger|success|warning|inverse)/)
+      },
     },
     /**
      * Handler function for when the cancel button is clicked.
@@ -378,6 +387,12 @@ export default {
       </h3>
       <oc-search-bar :isFilter="true" label="Search files" placeholder="Filter Files ..." :type-ahead="true" @search="onFilter" button="Filter" icon="" />
       <div v-if="filterQuery" class="oc-m">Filter query: {{ filterQuery }}</div>
+    </section>
+    <section>
+      <h3 class="oc-heading-divider">
+        Search with cancel button
+      </h3>
+      <oc-search-bar label="Search files" placeholder="Enter search term" :type-ahead="true" :show-cancel-button="true" />
     </section>
   </div>
 </template>

--- a/src/components/atoms/OcSearchBar/OcSearchBar.vue
+++ b/src/components/atoms/OcSearchBar/OcSearchBar.vue
@@ -280,13 +280,6 @@ export default {
 
   min-width: $form-width-medium;
 
-  @media (max-width: 639px) {
-    .oc-width-expand {
-      display: flex;
-      width: 100%;
-    }
-  }
-
   &-button {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;


### PR DESCRIPTION
## Description
We've added to possibility to have a "cancel"-button and -handler in the `OcSearchBar` component.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Needed for https://github.com/owncloud/web/issues/7617

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests
