### PR TITLE
Use passive color for button group outline

### DIFF
--- a/changelog/unreleased/enhancement-remove-button-border
+++ b/changelog/unreleased/enhancement-remove-button-border
@@ -6,3 +6,4 @@ https://github.com/owncloud/web/issues/7353
 https://github.com/owncloud/web/issues/7373
 https://github.com/owncloud/owncloud-design-system/pull/2345
 https://github.com/owncloud/owncloud-design-system/pull/2352
+https://github.com/owncloud/owncloud-design-system/pull/2354

--- a/src/components/atoms/OcButton/OcButton.vue
+++ b/src/components/atoms/OcButton/OcButton.vue
@@ -430,7 +430,7 @@ export default {
   &-group {
     display: inline-flex;
     flex-flow: row wrap;
-    outline: 1px solid var(--oc-color-swatch-primary-default);
+    outline: 1px solid var(--oc-color-swatch-passive-default);
     outline-offset: -1px;
     border-radius: 5px;
 


### PR DESCRIPTION
Follow-up for https://github.com/owncloud/owncloud-design-system/pull/2352. We (currently) only have passive button groups in Web, hence the outline should be passive as well.